### PR TITLE
Draw every select, menu, and scrollbar the same way

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -95,15 +95,16 @@ button { cursor: pointer; }
 button:disabled { cursor: not-allowed; opacity: .58; }
 button:focus-visible, a:focus-visible, [role]:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
 input:hover:not(:focus), textarea:hover:not(:focus), select:hover:not(:focus) { border-color: var(--field-border-hover); }
-input:focus, input:focus-visible, textarea:focus, select:focus { box-shadow: var(--field-ring); outline: none; }
+input:focus-visible, textarea:focus-visible, select:focus-visible { box-shadow: var(--field-ring); outline: none; }
 .file-picker:focus-within { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 
-.workspace, .entry-list, .login-card-area, .security-rail, .editor-fields, .keep-options { scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) transparent; }
-.workspace::-webkit-scrollbar, .entry-list::-webkit-scrollbar, .login-card-area::-webkit-scrollbar, .security-rail::-webkit-scrollbar, .editor-fields::-webkit-scrollbar, .keep-options::-webkit-scrollbar { width: 12px; height: 12px; }
-.workspace::-webkit-scrollbar-thumb, .entry-list::-webkit-scrollbar-thumb, .login-card-area::-webkit-scrollbar-thumb, .security-rail::-webkit-scrollbar-thumb, .editor-fields::-webkit-scrollbar-thumb, .keep-options::-webkit-scrollbar-thumb { border: 4px solid transparent; border-radius: var(--radius-pill); background: var(--scrollbar-thumb); background-clip: padding-box; }
-.workspace::-webkit-scrollbar-thumb:hover, .entry-list::-webkit-scrollbar-thumb:hover, .login-card-area::-webkit-scrollbar-thumb:hover, .security-rail::-webkit-scrollbar-thumb:hover, .editor-fields::-webkit-scrollbar-thumb:hover, .keep-options::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); background-clip: padding-box; }
-.workspace::-webkit-scrollbar-track, .entry-list::-webkit-scrollbar-track, .login-card-area::-webkit-scrollbar-track, .security-rail::-webkit-scrollbar-track, .editor-fields::-webkit-scrollbar-track, .keep-options::-webkit-scrollbar-track { background: transparent; }
+:root { scrollbar-color: var(--scrollbar-thumb) transparent; }
+* { scrollbar-width: thin; }
+*::-webkit-scrollbar { width: 12px; height: 12px; }
+*::-webkit-scrollbar-thumb { border: 4px solid transparent; border-radius: var(--radius-pill); background: var(--scrollbar-thumb); background-clip: padding-box; }
+*::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); background-clip: padding-box; }
+*::-webkit-scrollbar-track { background: transparent; }
 
 .topbar h1,
 .login-title-row h2,
@@ -181,14 +182,17 @@ button.no-totp, .credential-button, .more-button {
 
 /* Theme picker (Settings + top bar) + a matching pill-group pattern reused by
    the auto-lock and clipboard-timeout controls. */
-.theme-toggle, .auto-lock-options, .clipboard-clear-options { display: inline-flex; flex: none; gap: 2px; padding: 3px; border: 0; border-radius: var(--radius-md); background: var(--surface-inset); }
+.theme-toggle, .auto-lock-options, .clipboard-clear-options { position: relative; display: inline-flex; flex: none; gap: 2px; padding: 3px; border: 0; border-radius: var(--radius-md); background: var(--surface-inset); }
 .theme-toggle button { display: grid; width: 34px; height: 30px; place-items: center; border: 0; border-radius: var(--radius-sm); color: var(--text-muted); background: transparent; line-height: 0; transition: background-color .18s ease, color .18s ease, box-shadow .18s ease; }
 .theme-toggle button:hover:not(.active) { color: var(--accent-link); }
-.theme-toggle button.active { color: var(--accent-link); background: var(--control-active-bg); box-shadow: var(--control-active-edge), var(--control-active-lift); }
+.theme-toggle button.active { color: var(--accent-link); }
 .settings-view .theme-toggle { margin-left: auto; }
 .auto-lock-options button, .clipboard-clear-options button { min-width: 40px; height: 30px; border: 0; border-radius: var(--radius-sm); color: var(--text-muted); background: transparent; font-size: var(--type-1); font-weight: 700; transition: background-color .18s ease, color .18s ease, box-shadow .18s ease; }
 .auto-lock-options button:hover:not(.active), .clipboard-clear-options button:hover:not(.active) { color: var(--accent-link); }
-.auto-lock-options button.active, .clipboard-clear-options button.active { color: var(--accent-link); background: var(--control-active-bg); box-shadow: var(--control-active-edge), var(--control-active-lift); }
+.auto-lock-options button.active, .clipboard-clear-options button.active { color: var(--accent-link); }
+.segment-marker { position: absolute; top: 0; left: 0; z-index: 0; border-radius: var(--radius-sm); background: var(--control-active-bg); box-shadow: var(--control-active-edge), var(--control-active-lift); opacity: 0; pointer-events: none; }
+.segment-marker[data-placed] { opacity: 1; transition: transform .22s cubic-bezier(.2, .7, .2, 1), width .22s cubic-bezier(.2, .7, .2, 1), opacity .12s ease; }
+.theme-toggle button, .auto-lock-options button, .clipboard-clear-options button { position: relative; z-index: 1; }
 
 .status-pill { margin-left: auto; border-radius: var(--radius-md); padding: 3px var(--space-2); color: var(--ok-text); background: var(--ok-bg); font-size: var(--type-1); font-weight: 700; letter-spacing: .02em; }
 
@@ -220,7 +224,7 @@ button.no-totp, .credential-button, .more-button {
    clipped by the bottom edge, so the one message explaining why an action
    failed is the one message you cannot read. The backdrop insets 36px for the
    title bar and pads by --space-6, so the ceiling has to account for both. */
-.modal { position: relative; display: flex; flex-direction: column; width: min(100%, 480px); max-height: calc(100dvh - 36px - var(--space-6) * 2); overflow-y: auto; overscroll-behavior: contain; border: 0; border-radius: var(--radius-lg); padding: var(--space-6); color: var(--text); background: var(--surface); box-shadow: var(--control-active-edge), var(--shadow-modal); }
+.modal { animation: view-enter .2s cubic-bezier(.2, .7, .2, 1) both; position: relative; display: flex; flex-direction: column; width: min(100%, 480px); max-height: calc(100dvh - 36px - var(--space-6) * 2); overflow-y: auto; overscroll-behavior: contain; border: 0; border-radius: var(--radius-lg); padding: var(--space-6); color: var(--text); background: var(--surface); box-shadow: var(--control-active-edge), var(--shadow-modal); }
 /* Pinned to the bottom of that scroll area so Cancel and the primary action
    stay reachable without scrolling to find them. The negative offset and the
    padding cancel the shell's own padding, so the buttons sit flush. */
@@ -321,7 +325,7 @@ button.no-totp, .credential-button, .more-button {
 .unlock-card form { margin-top: var(--space-5); }
 .unlock-card label { display: block; margin: var(--space-4) 0 7px; color: var(--text-2); font-size: var(--type-1); font-weight: 700; }
 .unlock-card input:not([type="checkbox"]) { width: 100%; border: 1px solid transparent; border-radius: var(--radius-md); padding: 12px var(--space-3); color: var(--text); background: var(--surface-inset); transition: border-color .16s ease, box-shadow .16s ease; }
-.unlock-card input:not([type="checkbox"]):focus { box-shadow: var(--field-ring); outline: none; }
+.unlock-card input:not([type="checkbox"]):focus-visible { box-shadow: var(--field-ring); outline: none; }
 /* Six painted cells over one real input. The cells are decoration, so they
    take no pointer events and the click always lands on the field behind. */
 .pin-field { position: relative; display: flex; gap: 10px; margin-top: var(--space-5); }
@@ -452,7 +456,7 @@ button.no-totp, .credential-button, .more-button {
 .sort-select-trigger:hover:not(:disabled) { background: var(--tint); }
 .sort-select-trigger:disabled { color: var(--text-faint); cursor: not-allowed; }
 .sort-select-trigger svg { width: 11px; height: 11px; flex: none; fill: none; stroke: currentColor; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
-.sort-menu { position: absolute; z-index: 4; top: calc(100% + 5px); right: 0; left: 0; max-height: min(280px, 48vh); overflow-y: auto; padding: 5px; border: 1px solid var(--border-input); border-radius: var(--radius-md); background: var(--surface); box-shadow: var(--shadow-pop); }
+.sort-menu { transform-origin: top; animation: menu-in .14s cubic-bezier(.2, .7, .2, 1) both; position: absolute; z-index: 4; top: calc(100% + 5px); right: 0; width: max-content; min-width: 100%; max-width: min(18rem, 80vw); max-height: min(280px, 48vh); overflow-x: hidden; overflow-y: auto; padding: 5px; border: 1px solid var(--border-input); border-radius: var(--radius-md); background: var(--surface); box-shadow: var(--shadow-pop); }
 .sort-menu button { display: block; width: 100%; border: 0; border-radius: 6px; padding: 8px 10px; color: var(--text); background: transparent; text-align: left; font-size: var(--type-1); white-space: nowrap; }
 .sort-menu button:hover { color: var(--accent-link); background: var(--control-hover); }
 .sort-menu button.selected { color: var(--accent-link); background: var(--control-active-bg); box-shadow: var(--control-active-edge), var(--control-active-lift); }
@@ -489,7 +493,6 @@ button.no-totp, .credential-button, .more-button {
 .bulk-select-all { display: flex; min-width: 0; align-items: center; gap: var(--space-2); font-size: var(--type-1); font-weight: 650; }
 .bulk-select-all input, .entry-select-box { width: 16px; height: 16px; flex: none; accent-color: var(--accent); }
 .bulk-destination { display: flex; min-width: 0; gap: var(--space-2); }
-.bulk-toolbar select { min-width: 0; height: 32px; flex: 1; border: 1px solid var(--border-input); border-radius: var(--radius-sm); padding: 0 8px; color: var(--text); background: var(--surface); font-size: var(--type-1); }
 .bulk-move-button { min-height: 32px; padding: 0 var(--space-3); font-size: var(--type-1); }
 .bulk-toolbar-actions { display: flex; grid-column: 1 / -1; justify-content: flex-end; gap: var(--space-1); }
 .bulk-toolbar-actions .secondary-button, .bulk-toolbar-actions .editor-delete { min-height: 30px; }
@@ -531,7 +534,7 @@ button.no-totp, .credential-button, .more-button {
 .folder-badge { display: inline-flex; height: 23px; align-items: center; gap: 4px; border: 0; border-radius: var(--radius-pill); padding: 0 8px; color: var(--accent-link); background: var(--tint); font-size: 10px; font-weight: 650; line-height: 1; }
 .folder-badge:hover { background: var(--tint-hover); }
 
-.entry-context-menu { position: fixed; z-index: 90; display: grid; width: 264px; max-height: min(560px, calc(100vh - 52px)); padding: 6px; border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--text); background: color-mix(in srgb, var(--surface) 96%, transparent); box-shadow: var(--shadow-pop); backdrop-filter: blur(14px); overflow-y: auto; animation: context-menu-in .12s ease-out both; }
+.entry-context-menu { position: fixed; z-index: 90; display: grid; width: 264px; max-height: min(560px, calc(100vh - 52px)); padding: 6px; border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--text); background: color-mix(in srgb, var(--surface) 96%, transparent); box-shadow: var(--shadow-pop); backdrop-filter: blur(14px); overflow-y: auto; transform-origin: top; animation: menu-in .14s cubic-bezier(.2, .7, .2, 1) both; }
 .context-menu-heading { display: flex; min-width: 0; align-items: center; gap: 9px; padding: 8px 9px 10px; }
 .context-menu-heading > span:last-child { display: grid; min-width: 0; gap: 2px; }
 .context-menu-heading strong, .context-menu-heading small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -566,9 +569,9 @@ button.no-totp, .credential-button, .more-button {
 .folder-name-modal { width: min(100%, 430px); }
 .folder-name-modal label { display: grid; gap: 7px; margin-top: var(--space-5); color: var(--text); font-size: var(--type-1); font-weight: 700; }
 .folder-name-modal input { width: 100%; border: 1px solid var(--border-input); border-radius: var(--radius-md); padding: 11px 12px; color: var(--text); background: var(--surface-inset); }
-.folder-name-modal input:focus { box-shadow: var(--field-ring); outline: none; }
+.folder-name-modal input:focus-visible { box-shadow: var(--field-ring); outline: none; }
 
-@keyframes context-menu-in { from { opacity: 0; transform: scale(.975) translateY(-3px); } to { opacity: 1; transform: scale(1) translateY(0); } }
+@keyframes menu-in { from { opacity: 0; transform: scale(.98) translateY(-4px); } to { opacity: 1; transform: scale(1) translateY(0); } }
 .site-missing { display: block; color: var(--warn-text); font-size: var(--type-1); }
 .issue-chips { display: flex; flex-wrap: wrap; gap: var(--space-2); margin: var(--space-3) 0 0; }
 .issue-chip { display: inline-flex; align-items: center; gap: 5px; border-radius: var(--radius-pill); padding: 3px 9px; color: var(--warn-text); background: var(--warn-bg); font-size: var(--type-1); font-weight: 600; line-height: 1.3; white-space: nowrap; }
@@ -737,7 +740,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .pin-setup-modal form { display: grid; gap: var(--space-2); margin-top: var(--space-5); }
 .pin-setup-modal label { color: var(--text); font-size: var(--type-1); font-weight: 700; }
 .pin-setup-modal input { width: 100%; border: 1px solid var(--border-input); border-radius: var(--radius-sm); padding: 12px 14px; color: var(--text); background: var(--surface); font-family: var(--font-code); font-size: var(--type-4); letter-spacing: .24em; text-align: center; }
-.pin-setup-modal input:focus { box-shadow: var(--field-ring); outline: none; }
+.pin-setup-modal input:focus-visible { box-shadow: var(--field-ring); outline: none; }
 .pin-security-note { display: grid; grid-template-columns: auto 1fr; align-items: start; gap: var(--space-2); border-radius: var(--radius-sm); padding: var(--space-3); color: var(--text-muted); background: var(--surface-inset); font-size: var(--type-1); line-height: 1.45; }
 .pin-security-note svg { margin-top: 1px; color: var(--chip-icon); }
 .change-master-password-modal { width: min(100%, 480px); }
@@ -746,7 +749,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .change-master-password-modal form { display: grid; gap: var(--space-3); margin-top: var(--space-5); }
 .change-master-password-modal form label { display: grid; gap: 7px; color: var(--text); font-size: var(--type-1); font-weight: 700; }
 .change-master-password-modal form input { width: 100%; border: 1px solid var(--border-input); border-radius: var(--radius-sm); padding: 12px 14px; color: var(--text); background: var(--surface); }
-.change-master-password-modal form input:focus { box-shadow: var(--field-ring); outline: none; }
+.change-master-password-modal form input:focus-visible { box-shadow: var(--field-ring); outline: none; }
 
 .browser-fill-backdrop { z-index: 70; }
 .browser-fill-modal { width: min(100%, 540px); }
@@ -907,7 +910,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .drill-file small { color: var(--text-faint); font-size: var(--type-1); }
 .drill-secret { display: grid; gap: 7px; margin-top: var(--space-4); color: var(--text); font-size: var(--type-1); font-weight: 700; }
 .drill-secret input { width: 100%; border: 1px solid var(--border-input); border-radius: var(--radius-md); padding: 12px 13px; color: var(--text); background: var(--surface-inset); }
-.drill-secret input:focus { box-shadow: var(--field-ring); outline: none; }
+.drill-secret input:focus-visible { box-shadow: var(--field-ring); outline: none; }
 .drill-privacy { display: flex; align-items: center; gap: 6px; margin: var(--space-2) 0 0 !important; color: var(--text-faint) !important; font-size: var(--type-1) !important; }
 .drill-result { display: flex; align-items: flex-start; gap: var(--space-3); border-radius: var(--radius-md); padding: var(--space-4); color: var(--ok-text); background: var(--ok-bg); }
 .drill-result > span { display: grid; width: 34px; height: 34px; flex: none; place-items: center; border-radius: 50%; color: var(--ok-text); background: color-mix(in srgb, var(--ok-text) 12%, transparent); }
@@ -934,7 +937,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .restore-confirm { display: flex; align-items: flex-start; gap: var(--space-2); color: var(--text); font-size: var(--type-2); line-height: 1.4; }
 .restore-modal label[for="restore-secret"] { display: block; margin: var(--space-5) 0 var(--space-2); color: var(--text); font-size: var(--type-1); font-weight: 700; }
 .restore-modal input#restore-secret { width: 100%; border: 1px solid var(--border-input); border-radius: var(--radius-sm); padding: var(--space-3); color: var(--text); background: var(--surface); font-size: var(--type-3); }
-.restore-modal input#restore-secret:focus { box-shadow: var(--field-ring); outline: none; }
+.restore-modal input#restore-secret:focus-visible { box-shadow: var(--field-ring); outline: none; }
 .restore-confirm input { width: 17px; height: 17px; flex: none; margin: 1px 0 0; accent-color: var(--danger); }
 .restore-actions { display: flex; justify-content: flex-end; gap: var(--space-2); margin-top: var(--space-5); }
 
@@ -992,7 +995,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .settings-service-connect, .settings-service-actions { display: flex; flex: none !important; align-items: center; gap: var(--space-2); }
 .settings-service-connect { width: 238px; }
 .settings-service-connect input { width: 100%; min-width: 0; min-height: 34px; border: 1px solid var(--border-input); border-radius: var(--radius-sm); padding: 0 var(--space-3); color: var(--text); background: var(--surface-inset); font-family: var(--font-code); font-size: var(--type-1); outline: none; }
-.settings-service-connect input:focus { box-shadow: var(--field-ring); outline: none; }
+.settings-service-connect input:focus-visible { box-shadow: var(--field-ring); outline: none; }
 .settings-service-actions .text-button { white-space: nowrap; }
 .settings-service-actions .secondary-button { gap: 6px; white-space: nowrap; }
 .status-pill.offline { color: var(--warn-text); background: var(--warn-bg); }
@@ -1036,7 +1039,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .delete-vault-modal > p { margin: var(--space-2) 0 0; color: var(--text-muted); font-size: var(--type-2); line-height: 1.55; }
 .delete-vault-input { display: block; margin-top: var(--space-5); color: var(--text); font-size: var(--type-2); font-weight: 700; }
 .delete-vault-modal input { width: 100%; margin-top: var(--space-2); border: 1px solid var(--border-input); border-radius: var(--radius-sm); padding: var(--space-3); color: var(--text); background: var(--surface); font-size: var(--type-3); outline: none; }
-.delete-vault-modal input:focus { border-color: var(--danger); box-shadow: var(--field-ring-danger); outline: none; }
+.delete-vault-modal input:focus-visible { border-color: var(--danger); box-shadow: var(--field-ring-danger); outline: none; }
 
 /* =========================================================================
    Feature: import
@@ -1049,7 +1052,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .source-select { display: flex; width: 100%; align-items: center; justify-content: space-between; border: 0; border-radius: var(--radius-sm); padding: 10px; color: var(--text); background: var(--surface-inset); font-size: var(--type-2); text-align: left; }
 .source-select:hover { background: var(--tint); }
 .source-select svg { width: 13px; height: 13px; fill: none; stroke: currentColor; stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; }
-.source-menu { position: absolute; z-index: 4; top: calc(100% + 5px); right: 0; left: 0; max-height: min(360px, 48vh); overflow-y: auto; padding: 5px; border: 1px solid var(--border-input); border-radius: var(--radius-md); background: var(--surface); box-shadow: var(--shadow-pop); }
+.source-menu { transform-origin: top; animation: menu-in .14s cubic-bezier(.2, .7, .2, 1) both; position: absolute; z-index: 4; top: calc(100% + 5px); right: 0; left: 0; max-height: min(360px, 48vh); overflow-y: auto; padding: 5px; border: 1px solid var(--border-input); border-radius: var(--radius-md); background: var(--surface); box-shadow: var(--shadow-pop); }
 .source-menu button { display: block; width: 100%; border: 0; border-radius: 6px; padding: 9px 10px; color: var(--text); background: transparent; text-align: left; font-size: var(--type-2); }
 .source-menu button:hover { color: var(--accent-link); background: var(--control-hover); }
 .source-menu button.selected { color: var(--accent-link); background: var(--control-active-bg); box-shadow: var(--control-active-edge), var(--control-active-lift); }
@@ -1085,7 +1088,7 @@ button.no-totp:hover { filter: brightness(.97); }
    Feature: login editor
    ========================================================================= */
 .editor-backdrop { z-index: 30; }
-.login-editor { display: flex; width: min(100%, 650px); max-height: min(790px, calc(100vh - 86px)); flex-direction: column; overflow: hidden; padding: 0; animation: view-enter .2s ease-out both; }
+.login-editor { display: flex; width: min(100%, 650px); max-height: min(790px, calc(100vh - 86px)); flex-direction: column; overflow: hidden; padding: 0; }
 .login-editor > form { display: flex; min-height: 0; flex: 1; flex-direction: column; }
 .editor-header { position: relative; display: flex; align-items: flex-start; justify-content: space-between; padding: 28px 58px 22px 28px; border-bottom: 1px solid var(--border-soft); }
 .editor-header .eyebrow { margin-bottom: 5px; }
@@ -1102,7 +1105,10 @@ button.no-totp:hover { filter: brightness(.97); }
 .document-attachment-badge { display: inline-flex; align-items: center; gap: 3px; flex: none; color: var(--text-muted); font-size: var(--type-1); }
 .editor-fields > label, .editor-two-column > label, .editor-section > label { display: grid; gap: 7px; color: var(--text-2); font-size: var(--type-1); font-weight: 700; }
 .editor-fields input:not([type="checkbox"]), .editor-fields textarea, .editor-fields select { width: 100%; border: 1px solid transparent; border-radius: var(--radius-sm); padding: 10px 11px; color: var(--text); background: var(--surface-inset); font-size: var(--type-2); outline: none; transition: border-color .16s ease, box-shadow .16s ease; }
-.editor-fields input:not([type="checkbox"]):focus, .editor-fields textarea:focus, .editor-fields select:focus { box-shadow: var(--field-ring); }
+.editor-fields input:not([type="checkbox"]):focus-visible, .editor-fields textarea:focus-visible, .editor-fields select:focus-visible { box-shadow: var(--field-ring); }
+.editor-fields .sort-select-trigger, .editor-two-column .sort-select-trigger, .editor-section .sort-select-trigger, .item-collection-row .sort-select-trigger, .custom-field-row .sort-select-trigger { width: 100%; height: auto; border: 1px solid transparent; border-radius: var(--radius-sm); padding: 10px 11px; color: var(--text); background: var(--surface-inset); font-size: var(--type-2); font-weight: inherit; }
+.editor-fields .sort-select-trigger:hover:not(:disabled), .editor-two-column .sort-select-trigger:hover:not(:disabled), .editor-section .sort-select-trigger:hover:not(:disabled) { background: var(--surface-inset); border-color: var(--field-border-hover); }
+.editor-fields .sort-control, .editor-two-column .sort-control, .editor-section .sort-control { display: block; }
 .editor-fields textarea { min-height: 82px; resize: vertical; line-height: 1.45; }
 .editor-two-column { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
 .editor-section { display: grid; gap: 14px; border-top: 1px solid var(--border-soft); padding-top: 21px; }
@@ -1167,7 +1173,7 @@ button.no-totp:hover { filter: brightness(.97); }
   .view-header-aside { border-top: 1px solid var(--border-strong); border-left: 0; padding-left: 0; text-align: left; }
   .credential-row { grid-template-columns: 105px minmax(0, 1fr) auto auto auto; }
   .bulk-toolbar { grid-template-columns: 1fr auto; }
-  .bulk-toolbar select { grid-column: 1; }
+  .bulk-toolbar .sort-control { grid-column: 1; }
   .backup-card { align-items: flex-start; flex-direction: column; }
   .settings-view article { flex-wrap: wrap; }
   .settings-service-connect, .settings-service-actions { width: calc(100% - 52px); margin-left: 52px; }
@@ -1218,11 +1224,10 @@ button.no-totp:hover { filter: brightness(.97); }
 .custom-fields-section { display: grid; gap: var(--space-2); }
 .custom-field-row { display: grid; grid-template-columns: 1fr 1fr auto auto; gap: var(--space-2); align-items: center; }
 .custom-field-label, .custom-field-value { width: 100%; border: 1px solid transparent; border-radius: var(--radius-sm); padding: 10px 11px; color: var(--text); background: var(--surface-inset); font-size: var(--type-2); outline: none; transition: border-color .16s ease, box-shadow .16s ease; }
-.custom-field-label:focus, .custom-field-value:focus { box-shadow: var(--field-ring); }
-.custom-field-kind { border: 1px solid transparent; border-radius: var(--radius-sm); padding: 10px 8px; color: var(--text); background: var(--surface-inset); font-size: var(--type-1); }
+.custom-field-label:focus-visible, .custom-field-value:focus-visible { box-shadow: var(--field-ring); }
 .custom-field-add { justify-self: start; }
 
-.trash-view { max-width: 640px; }
+.trash-view { max-width: 640px; animation: view-enter .28s cubic-bezier(.2,.7,.2,1) both; }
 .trash-empty-icon { display: grid; place-items: center; color: var(--gold-text); background: var(--gold-soft-bg); border-radius: var(--radius-lg); }
 .trash-list { display: grid; gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
 .trash-row { display: flex; align-items: center; gap: var(--space-3); border-radius: var(--radius-lg); padding: var(--space-3) var(--space-4); background: var(--surface); box-shadow: var(--shadow-panel); }
@@ -1231,7 +1236,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .trash-row-detail small { color: var(--text-muted); font-size: var(--type-1); }
 .trash-row-actions { display: flex; gap: var(--space-1); }
 
-.history-view { max-width: 640px; }
+.history-view { max-width: 640px; animation: view-enter .28s cubic-bezier(.2,.7,.2,1) both; }
 .history-empty-icon { display: grid; place-items: center; color: var(--gold-text); background: var(--gold-soft-bg); border-radius: var(--radius-lg); }
 .history-list { display: grid; gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
 .history-row { display: flex; align-items: center; gap: var(--space-3); border-radius: var(--radius-lg); padding: var(--space-3) var(--space-4); background: var(--surface); box-shadow: var(--shadow-panel); }
@@ -1251,7 +1256,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .monospace-field { font-family: var(--font-code); font-size: var(--type-1); }
 
 .add-item-menu { position: relative; }
-.add-item-options { position: absolute; z-index: 40; top: calc(100% + 6px); right: 0; display: grid; min-width: 190px; gap: 2px; padding: 5px; border-radius: var(--radius-md); background: var(--surface); box-shadow: var(--shadow-raise), var(--shadow-panel); }
+.add-item-options { transform-origin: top; animation: menu-in .14s cubic-bezier(.2, .7, .2, 1) both; position: absolute; z-index: 40; top: calc(100% + 6px); right: 0; display: grid; min-width: 190px; gap: 2px; padding: 5px; border-radius: var(--radius-md); background: var(--surface); box-shadow: var(--shadow-raise), var(--shadow-panel); }
 .add-item-options button { display: flex; align-items: center; gap: var(--space-2); border: 0; border-radius: var(--radius-sm); padding: 8px 10px; color: var(--text); background: transparent; font-size: var(--type-1); text-align: left; cursor: pointer; }
 .add-item-options button:hover, .add-item-options button:focus-visible { color: var(--text-heading); background: var(--tint); }
 
@@ -1266,7 +1271,7 @@ button.no-totp:hover { filter: brightness(.97); }
 .attachment-list li { display: flex; align-items: center; gap: var(--space-2); border-radius: var(--radius-sm); padding: var(--space-2); color: var(--text); background: var(--surface-inset); font-size: var(--type-1); }
 .attachment-list small { margin-left: auto; color: var(--text-faint); }
 .item-collection-row { display: flex; align-items: center; gap: var(--space-2); margin-top: var(--space-2); }
-.item-collection-row select { flex: 1; min-width: 0; border: 1px solid transparent; border-radius: var(--radius-sm); padding: 10px 11px; color: var(--text); background: var(--surface-inset); font-size: var(--type-2); }
+.item-collection-row .sort-control { flex: 1; min-width: 0; }
 .rail-title { margin: 0 0 var(--space-3); color: var(--text-muted); font-size: var(--type-1); font-weight: 600; }
 
 .filter-menu { position: relative; display: flex; min-width: 0; }
@@ -1274,6 +1279,8 @@ button.no-totp:hover { filter: brightness(.97); }
 .filter-trigger > span { overflow: hidden; flex: 1; min-width: 0; text-align: left; text-overflow: ellipsis; }
 .filter-trigger > svg:first-child { flex: none; }
 .filter-options {
+  transform-origin: top;
+  animation: menu-in .14s cubic-bezier(.2, .7, .2, 1) both;
   position: absolute;
   z-index: 40;
   top: calc(100% + 5px);

--- a/src/lib/ui/CustomRecordEditor.svelte
+++ b/src/lib/ui/CustomRecordEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ModalShell from './ModalShell.svelte'
+  import SelectMenu from './SelectMenu.svelte'
   import Icon from '../Icon.svelte'
   import type { CustomFieldEntry, CustomRecordInput } from '../types'
 
@@ -82,11 +83,12 @@
             type={field.kind === 'secret' ? 'password' : 'text'}
             class="custom-field-value"
           />
-          <select value={field.kind} on:change={(event) => updateField(index, { kind: event.currentTarget.value })} class="custom-field-kind">
-            <option value="text">Text</option>
-            <option value="secret">Secret</option>
-            <option value="date">Date</option>
-          </select>
+          <SelectMenu
+            label={`Field ${index + 1} kind`}
+            value={field.kind}
+            options={[{ value: 'text', label: 'Text' }, { value: 'secret', label: 'Secret' }, { value: 'date', label: 'Date' }]}
+            onChange={(kind) => updateField(index, { kind })}
+          />
           <button type="button" class="icon-button" aria-label={`Remove field ${index + 1}`} title="Remove field" on:click={() => removeField(index)}><Icon name="trash" size={14} /></button>
         </div>
       {/each}

--- a/src/lib/ui/ImportModal.svelte
+++ b/src/lib/ui/ImportModal.svelte
@@ -6,6 +6,20 @@
   import ModalShell from './ModalShell.svelte'
 
   export let importSources: Array<{ value: ImportSource; label: string }>
+
+  let sourceMenu: HTMLElement | undefined
+
+  async function fitMenuInsideModal() {
+    await tick()
+    if (!sourceMenu || !sourceButton) return
+    const modal = sourceMenu.closest('.modal')
+    if (!modal) return
+    const room = modal.getBoundingClientRect().bottom - sourceButton.getBoundingClientRect().bottom
+    const available = Math.max(120, Math.round(room - 24))
+    sourceMenu.style.maxHeight = `${available}px`
+  }
+
+  $: if ($imports.sourceMenuOpen) void fitMenuInsideModal()
   export let onClose: () => void
   export let onChooseSource: (source: ImportSource) => void
   export let onHandleImport: () => void
@@ -104,7 +118,7 @@
       <svg viewBox="0 0 12 12" aria-hidden="true"><path d="m3 4.5 3 3 3-3" /></svg>
     </button>
     {#if $imports.sourceMenuOpen}
-      <div id="import-source-options" class="source-menu" role="listbox" aria-labelledby="import-source-label">
+      <div bind:this={sourceMenu} id="import-source-options" class="source-menu" role="listbox" aria-labelledby="import-source-label">
         {#each importSources as source (source.value)}
           <button id={`import-source-${source.value}`} type="button" class:selected={source.value === $imports.source} role="option" aria-selected={source.value === $imports.source} tabindex="-1" on:click={() => chooseSource(source.value)} on:keydown={handleOptionKeydown}>{source.label}</button>
         {/each}

--- a/src/lib/ui/ItemDetail.svelte
+++ b/src/lib/ui/ItemDetail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import Icon from '../Icon.svelte'
+  import SelectMenu from './SelectMenu.svelte'
   import type { ItemDetail } from '../item-fields'
   import type { Folder, ItemKind } from '../types'
   import { itemKindIcon, itemKindLabel } from '../vault-items'
@@ -125,11 +126,13 @@
 <section class="details-section">
   <div class="section-heading"><h3>Collection</h3></div>
   <div class="item-collection-row">
-    <label class="sr-only" for="item-collection-select">Collection</label>
-    <select id="item-collection-select" value={detail.folderId ?? ''} on:change={(event) => onMove(event.currentTarget.value || undefined)}>
-      <option value="">Unfiled</option>
-      {#each folders as folder (folder.id)}<option value={folder.id}>{folder.name}</option>{/each}
-    </select>
+    <SelectMenu
+      id="item-collection-select"
+      label="Collection"
+      value={detail.folderId ?? ''}
+      options={[{ value: '', label: 'Unfiled' }, ...folders.map((folder) => ({ value: folder.id, label: folder.name }))]}
+      onChange={(next) => onMove(next || undefined)}
+    />
     <button type="button" class="editor-delete" on:click={onDelete}>Delete</button>
   </div>
 </section>

--- a/src/lib/ui/LoginEditor.svelte
+++ b/src/lib/ui/LoginEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ModalShell from './ModalShell.svelte'
+  import SelectMenu from './SelectMenu.svelte'
   import Icon from '../Icon.svelte'
   import { generatorLabels, generatorOptionKeys } from '../generator'
   import { useAppStores } from '../stores/app-stores'
@@ -87,8 +88,7 @@
     }
   }
 
-  function setFolder(event: Event) {
-    const folderId = (event.currentTarget as HTMLSelectElement).value
+  function setFolder(folderId: string) {
     const folder = folderOptions.find((candidate) => candidate.id === folderId)
     loginDraft = { ...loginDraft, folderId: folder?.id, folder: folder?.name ?? '' }
   }
@@ -114,7 +114,14 @@
     <label>Website <span class="field-hint">Used for opening and browser filling; "www" is treated as the same site</span><input bind:this={urlInput} bind:value={loginDraft.url} maxlength="2048" placeholder="e.g. github.com" inputmode="url" autocomplete="url" /></label>
     <label>Additional websites <span class="field-hint">One http or https address per line. Sesame does not fill across origins.</span><textarea value={(loginDraft.urls ?? []).join('\n')} on:input={(event) => (loginDraft = { ...loginDraft, urls: event.currentTarget.value.split('\n').map((value) => value.trim()).filter(Boolean) })} placeholder="https://github.com/login"></textarea></label>
     <label>Tags <span class="field-hint">Optional. Separate tags with commas.</span><input value={(loginDraft.tags ?? []).join(', ')} on:input={(event) => (loginDraft = { ...loginDraft, tags: event.currentTarget.value.split(',').map((value) => value.trim()).filter(Boolean) })} maxlength="10000" autocomplete="off" /></label>
-    <label>Folder <span class="field-hint">Optional. Create and rename folders from the vault organizer.</span><select value={loginDraft.folderId ?? ''} on:change={setFolder}><option value="">Unfiled</option>{#each folderOptions as folder (folder.id)}<option value={folder.id}>{folder.name}</option>{/each}</select></label>
+    <label>Folder <span class="field-hint">Optional. Create and rename folders from the vault organizer.</span>
+      <SelectMenu
+        label="Folder"
+        value={loginDraft.folderId ?? ''}
+        options={[{ value: '', label: 'Unfiled' }, ...folderOptions.map((folder) => ({ value: folder.id, label: folder.name }))]}
+        onChange={setFolder}
+      />
+    </label>
     <div class="editor-two-column">
       <label>Username <span class="field-hint">What the site calls a sign-in name, if it is not your email</span><input bind:value={loginDraft.username} maxlength="2048" autocomplete="username" list="username-suggestions" on:focus={() => loadSuggestions('username')} /></label>
       <label>Email <span class="field-hint">Only if the site asks for this separately from a username</span><input bind:value={loginDraft.email} maxlength="2048" inputmode="email" autocomplete="email" list="email-suggestions" on:focus={() => loadSuggestions('email')} /></label>

--- a/src/lib/ui/QuickAccessView.svelte
+++ b/src/lib/ui/QuickAccessView.svelte
@@ -169,7 +169,7 @@
     {#if items.length}
       <ul class="quick-access-results">
         {#each items as item, index (item.id)}
-          <li class="quick-access-result-row">
+          <li class="quick-access-result-row" class:active={index === selectedIndex}>
             <button type="button" class:active={index === selectedIndex} on:mouseenter={() => (selectedIndex = index)} on:click={() => { const action = primaryAction(item); if (action) void runAction(item, action) }} disabled={Boolean(workingId) && workingId !== item.id}>
               <span class="entry-avatar" aria-hidden="true">
                 {#if item.kind === 'login'}<WebsiteIcon site={item.subtitle} initials={item.initials} enabled={siteIconsEnabled} />{:else}<Icon name={itemKindIcon(item.kind)} size={15} />{/if}
@@ -177,6 +177,7 @@
               <span class="quick-access-result-copy"><strong>{item.title}</strong><small>{item.subtitle || itemKindLabel(item.kind)}</small></span>
               <span class="quick-access-result-state">{#if doneId === item.id}{doneLabel} copied{:else if workingId === item.id}Working…{:else}<Icon name="copy" size={13} />{primaryAction(item)?.label ?? 'No action'}{/if}</span>
             </button>
+            <span class="quick-access-actions">
             {#each item.actions.slice(1) as action (action.field)}
               <button
                 type="button"
@@ -192,6 +193,7 @@
                 <span>{confirming?.id === item.id && confirming?.field === action.field ? 'Confirm' : action.label.replace(/^Copy /, '')}</span>
               </button>
             {/each}
+            </span>
           </li>
         {/each}
       </ul>
@@ -206,14 +208,17 @@
 
 <style>
   :global(body) { min-width: 0; background: transparent; }
-  .quick-access { display: flex; flex-direction: column; box-sizing: border-box; width: 100%; height: 100vh; padding: var(--space-3); border-radius: var(--radius-lg); background: var(--surface); box-shadow: var(--shadow-raise), var(--shadow-panel); overflow: hidden; }
+  .quick-access { animation: view-enter .16s cubic-bezier(.2, .7, .2, 1) both; display: flex; flex-direction: column; box-sizing: border-box; width: 100%; height: 100vh; padding: var(--space-3); border-radius: var(--radius-lg); background: var(--surface); box-shadow: var(--shadow-raise), var(--shadow-panel); overflow: hidden; }
   .quick-access-status { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-3); flex: 1; color: var(--text-muted); font-size: var(--type-2); text-align: center; }
   .quick-access-search { display: flex; align-items: center; gap: var(--space-2); flex: none; border-radius: var(--radius-md); padding: 0 var(--space-3); color: var(--text-muted); background: var(--surface-inset); }
   .quick-access-search input { flex: 1; min-width: 0; border: 0; background: transparent; padding: 12px 0; color: var(--text); font-size: var(--type-3); }
   .quick-access-search input:focus { box-shadow: none; }
-  .quick-access-results { display: flex; flex-direction: column; gap: 2px; margin: var(--space-2) 0 0; padding: 0; list-style: none; overflow-y: auto; }
-  .quick-access-result-row { display: flex; min-width: 0; align-items: center; gap: var(--space-1); }
-  .quick-access-result-row > button:first-child { display: flex; min-width: 0; flex: 1; align-items: center; gap: var(--space-2); border: 0; border-radius: var(--radius-sm); padding: var(--space-2); color: var(--text); background: transparent; text-align: left; cursor: pointer; }
+  .quick-access-results { display: flex; flex-direction: column; gap: 2px; margin: var(--space-2) 0 0; padding: 0 var(--space-1) 0 0; list-style: none; overflow-y: auto; scrollbar-gutter: stable; }
+  .quick-access-result-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; min-width: 0; align-items: center; gap: var(--space-1); }
+  .quick-access-result-row > button:first-child { display: grid; grid-template-columns: 32px minmax(0, 1fr) auto; min-width: 0; align-items: center; gap: var(--space-2); border: 0; border-radius: var(--radius-sm); padding: var(--space-2); color: var(--text); background: transparent; text-align: left; cursor: pointer; }
+  .quick-access-actions { display: flex; align-items: center; justify-content: flex-end; gap: var(--space-1); }
+  .quick-access-result-row:not(.active) .quick-access-actions,
+  .quick-access-result-row:not(.active) .quick-access-result-state { display: none; }
   .quick-access-result-row > button:first-child.active, .quick-access-result-row > button:first-child:hover:not(:disabled) { background: var(--tint); }
   .quick-access-result-row > button:first-child:disabled { cursor: default; opacity: .7; }
   .quick-access-action-button { display: inline-flex; min-height: 32px; flex: none; align-items: center; gap: 6px; border: 0; border-radius: var(--radius-sm); padding: 0 var(--space-2); color: var(--accent-link); background: var(--surface-inset); font-size: var(--type-1); font-weight: 650; white-space: nowrap; cursor: pointer; }
@@ -223,7 +228,7 @@
   .quick-access-result-copy { display: flex; flex-direction: column; min-width: 0; flex: 1; }
   .quick-access-result-copy strong { overflow: hidden; font-size: var(--type-2); text-overflow: ellipsis; white-space: nowrap; }
   .quick-access-result-copy small { overflow: hidden; color: var(--text-muted); font-size: var(--type-1); text-overflow: ellipsis; white-space: nowrap; }
-  .quick-access-result-state { display: inline-flex; flex: none; align-items: center; gap: 5px; color: var(--text-faint); font-size: 11px; font-weight: 600; }
+  .quick-access-result-state { display: inline-flex; align-items: center; justify-self: end; gap: 5px; color: var(--text-faint); font-size: 11px; font-weight: 600; white-space: nowrap; }
   .quick-access-empty { margin: var(--space-4) 0 0; color: var(--text-muted); font-size: var(--type-1); text-align: center; }
   .quick-access-confirm { margin: var(--space-2) 0 0; padding: 0 var(--space-2); color: var(--text-faint); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .quick-access-confirm { color: var(--danger); }

--- a/src/lib/ui/SelectMenu.svelte
+++ b/src/lib/ui/SelectMenu.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  export let value: string
+  export let options: Array<{ value: string; label: string }>
+  export let onChange: (value: string) => void
+  export let label: string
+  export let id: string | undefined = undefined
+  export let disabled = false
+  export let triggerClass = ''
+
+  let open = false
+  let container: HTMLElement
+  let trigger: HTMLButtonElement
+
+  $: selectedLabel = options.find((option) => option.value === value)?.label ?? ''
+
+  function optionButtons() {
+    return [...(container?.querySelectorAll<HTMLButtonElement>('[role="option"]') ?? [])]
+  }
+
+  function close(returnFocus: boolean) {
+    open = false
+    if (returnFocus) trigger?.focus()
+  }
+
+  function choose(next: string) {
+    onChange(next)
+    close(true)
+  }
+
+  function handleOutside(event: MouseEvent) {
+    if (open && container && !container.contains(event.target as Node)) close(false)
+  }
+
+  function handleTriggerKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      open = true
+      const buttons = optionButtons()
+      const selected = buttons.find((button) => button.getAttribute('aria-selected') === 'true')
+      ;(selected ?? buttons[0])?.focus()
+    }
+  }
+
+  function handleOptionKeydown(event: KeyboardEvent) {
+    const buttons = optionButtons()
+    const current = Math.max(0, buttons.indexOf(event.currentTarget as HTMLButtonElement))
+    let next: number | null = null
+    if (event.key === 'ArrowDown') next = (current + 1) % buttons.length
+    if (event.key === 'ArrowUp') next = (current - 1 + buttons.length) % buttons.length
+    if (event.key === 'Home') next = 0
+    if (event.key === 'End') next = buttons.length - 1
+    if (next !== null) {
+      event.preventDefault()
+      buttons[next]?.focus()
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      close(true)
+      return
+    }
+    if (event.key === 'Tab') close(false)
+  }
+</script>
+
+<svelte:window on:mousedown={handleOutside} />
+
+<div class="sort-control" bind:this={container}>
+  <button
+    bind:this={trigger}
+    {id}
+    type="button"
+    class="sort-select-trigger {triggerClass}"
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    aria-label={label}
+    {disabled}
+    on:click={() => (open = !open)}
+    on:keydown={handleTriggerKeydown}
+  >
+    <span>{selectedLabel}</span>
+    <svg viewBox="0 0 12 12" aria-hidden="true"><path d="M2.5 4.5 6 8l3.5-3.5" /></svg>
+  </button>
+  {#if open}
+    <div class="sort-menu" role="listbox" aria-label={label}>
+      {#each options as option (option.value)}
+        <button
+          type="button"
+          class:selected={option.value === value}
+          role="option"
+          aria-selected={option.value === value}
+          tabindex="-1"
+          on:click={() => choose(option.value)}
+          on:keydown={handleOptionKeydown}
+        >{option.label}</button>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/lib/ui/SettingsView.svelte
+++ b/src/lib/ui/SettingsView.svelte
@@ -152,6 +152,38 @@
     tabButtons[nextIndex]?.focus()
   }
 
+
+  function slidingSelection(node: HTMLElement) {
+    const marker = document.createElement('span')
+    marker.className = 'segment-marker'
+    marker.setAttribute('aria-hidden', 'true')
+    node.prepend(marker)
+
+    function place() {
+      const active = node.querySelector<HTMLElement>('button.active')
+      if (!active) {
+        delete marker.dataset.placed
+        return
+      }
+      marker.style.width = `${active.offsetWidth}px`
+      marker.style.height = `${active.offsetHeight}px`
+      marker.style.transform = `translate(${active.offsetLeft}px, ${active.offsetTop}px)`
+      if (!marker.dataset.placed) requestAnimationFrame(() => (marker.dataset.placed = 'true'))
+    }
+
+    place()
+    const selection = new MutationObserver(place)
+    selection.observe(node, { attributes: true, attributeFilter: ['class'], subtree: true })
+    const resize = new ResizeObserver(place)
+    resize.observe(node)
+    return {
+      destroy() {
+        selection.disconnect()
+        resize.disconnect()
+        marker.remove()
+      },
+    }
+  }
 </script>
 
 <svelte:window on:keydown={handleShortcutKeydown} />
@@ -186,7 +218,7 @@
             <article>
               <span class="settings-icon"><Icon name="monitor" size={17} /></span>
               <div class="setting-copy"><strong>Theme</strong><p>Match your system, or force light or dark.</p></div>
-              <div class="theme-toggle" role="group" aria-label="Theme"><button type="button" class:active={theme === 'light'} aria-pressed={theme === 'light'} aria-label="Light" on:click={() => onSetTheme('light')}><Icon name="sun" size={15} /></button><button type="button" class:active={theme === 'auto'} aria-pressed={theme === 'auto'} aria-label="System" on:click={() => onSetTheme('auto')}><Icon name="monitor" size={15} /></button><button type="button" class:active={theme === 'dark'} aria-pressed={theme === 'dark'} aria-label="Dark" on:click={() => onSetTheme('dark')}><Icon name="moon" size={15} /></button></div>
+              <div class="theme-toggle" role="group" aria-label="Theme" use:slidingSelection><button type="button" class:active={theme === 'light'} aria-pressed={theme === 'light'} aria-label="Light" on:click={() => onSetTheme('light')}><Icon name="sun" size={15} /></button><button type="button" class:active={theme === 'auto'} aria-pressed={theme === 'auto'} aria-label="System" on:click={() => onSetTheme('auto')}><Icon name="monitor" size={15} /></button><button type="button" class:active={theme === 'dark'} aria-pressed={theme === 'dark'} aria-label="Dark" on:click={() => onSetTheme('dark')}><Icon name="moon" size={15} /></button></div>
             </article>
             <article>
               <span class="settings-icon"><Icon name="globe" size={17} /></span>
@@ -243,7 +275,7 @@
             <article>
               <span class="settings-icon"><Icon name="lock" size={16} /></span>
               <div class="setting-copy"><strong>Automatic lock</strong><p>Lock the vault after a period without keyboard or pointer activity.</p></div>
-              <div class="auto-lock-options" role="group" aria-label="Automatic lock delay">{#each autoLockOptions as minutes (minutes)}<button type="button" class:active={autoLockMinutes === minutes} aria-pressed={autoLockMinutes === minutes} aria-label={`${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`} on:click={() => onSetAutoLockMinutes(minutes)}>{minutes}m</button>{/each}</div>
+              <div class="auto-lock-options" role="group" aria-label="Automatic lock delay" use:slidingSelection>{#each autoLockOptions as minutes (minutes)}<button type="button" class:active={autoLockMinutes === minutes} aria-pressed={autoLockMinutes === minutes} aria-label={`${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`} on:click={() => onSetAutoLockMinutes(minutes)}>{minutes}m</button>{/each}</div>
             </article>
             <article>
               <span class="settings-icon"><Icon name="key" size={16} /></span>
@@ -258,7 +290,7 @@
             <article>
               <span class="settings-icon"><Icon name="copy" size={16} /></span>
               <div class="setting-copy"><strong>Clipboard timeout</strong><p>How long a copied password or code stays on the clipboard before Sesame clears it.</p></div>
-              <div class="clipboard-clear-options" role="group" aria-label="Clipboard clear delay">{#each clipboardClearOptions as seconds (seconds)}<button type="button" class:active={clipboardClearSeconds === seconds} aria-pressed={clipboardClearSeconds === seconds} aria-label={`${seconds} seconds`} on:click={() => onSetClipboardClearSeconds(seconds)}>{seconds}s</button>{/each}</div>
+              <div class="clipboard-clear-options" role="group" aria-label="Clipboard clear delay" use:slidingSelection>{#each clipboardClearOptions as seconds (seconds)}<button type="button" class:active={clipboardClearSeconds === seconds} aria-pressed={clipboardClearSeconds === seconds} aria-label={`${seconds} seconds`} on:click={() => onSetClipboardClearSeconds(seconds)}>{seconds}s</button>{/each}</div>
             </article>
           </div>
         </section>

--- a/src/lib/ui/SwitchingJourneyModal.svelte
+++ b/src/lib/ui/SwitchingJourneyModal.svelte
@@ -18,6 +18,8 @@
 
   $: storeSwitchingChecklist(checklist)
 
+  const focusDialog = (dialog: HTMLElement) => dialog.focus({ preventScroll: true })
+
   function openBackups() {
     onClose()
     onOpenBackups()
@@ -35,7 +37,7 @@
   }
 </script>
 
-<ModalShell onClose={onClose} labelledby="switching-journey-heading" describedby="switching-journey-description" tone="switching-journey">
+<ModalShell onClose={onClose} labelledby="switching-journey-heading" describedby="switching-journey-description" tone="switching-journey" initialFocus={focusDialog}>
   <span class="switching-journey-icon"><Icon name="archive" size={21} /></span>
   <p class="eyebrow">Switching guide</p>
   <h2 id="switching-journey-heading">Move to Sesame in small steps</h2>

--- a/src/lib/ui/VaultView.svelte
+++ b/src/lib/ui/VaultView.svelte
@@ -123,6 +123,9 @@
   let sortMenuOpen = false
   let sortContainer: HTMLElement
   let sortButton: HTMLButtonElement
+  let folderMenuOpen = false
+  let folderContainer: HTMLElement
+  let folderButton: HTMLButtonElement
 
   function sortOptionButtons() {
     return [...(sortContainer?.querySelectorAll<HTMLButtonElement>('[role="option"]') ?? [])]
@@ -172,6 +175,59 @@
     }
     if (event.key === 'Tab') closeSortMenu(false)
   }
+
+  function folderOptionButtons() {
+    return [...(folderContainer?.querySelectorAll<HTMLButtonElement>('[role="option"]') ?? [])]
+  }
+
+  function closeFolderMenu(returnFocus: boolean) {
+    folderMenuOpen = false
+    if (returnFocus) folderButton?.focus()
+  }
+
+  function chooseBulkFolder(id: string) {
+    onSetBulkFolderId(id)
+    closeFolderMenu(true)
+  }
+
+  function handleFolderOutside(event: MouseEvent) {
+    if (folderMenuOpen && folderContainer && !folderContainer.contains(event.target as Node)) closeFolderMenu(false)
+  }
+
+  function handleFolderTriggerKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      folderMenuOpen = true
+      const options = folderOptionButtons()
+      const selected = options.find((option) => option.getAttribute('aria-selected') === 'true')
+      ;(selected ?? options[0])?.focus()
+    }
+  }
+
+  function handleFolderOptionKeydown(event: KeyboardEvent) {
+    const options = folderOptionButtons()
+    const current = Math.max(0, options.indexOf(event.currentTarget as HTMLButtonElement))
+    let next: number | null = null
+    if (event.key === 'ArrowDown') next = (current + 1) % options.length
+    if (event.key === 'ArrowUp') next = (current - 1 + options.length) % options.length
+    if (event.key === 'Home') next = 0
+    if (event.key === 'End') next = options.length - 1
+    if (next !== null) {
+      event.preventDefault()
+      options[next]?.focus()
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeFolderMenu(true)
+      return
+    }
+    if (event.key === 'Tab') closeFolderMenu(false)
+  }
+
+  $: bulkFolderLabel = bulkFolderId
+    ? folders.find((folder) => folder.id === bulkFolderId)?.name ?? 'Unfiled'
+    : 'Unfiled'
 
   function clearPasswordRevealTimer() {
     if (passwordRevealTimer) clearTimeout(passwordRevealTimer)
@@ -245,7 +301,7 @@
   }
 </script>
 
-<svelte:window on:keydown={handleWindowKeydown} on:mousedown={handleSortOutside} />
+<svelte:window on:keydown={handleWindowKeydown} on:mousedown={handleSortOutside} on:mousedown={handleFolderOutside} />
 
 {#if !allItems.length}
   <section class="empty-workspace">
@@ -323,10 +379,29 @@
         <div class="bulk-toolbar" role="region" aria-label="Bulk item actions">
           <label class="bulk-select-all"><input type="checkbox" checked={allVisibleSelected} aria-label="Select all visible items" on:change={() => onSelectVisible(allVisibleSelected ? [] : visibleItems.map((item) => item.id))} /><span>{selectedIds.length} selected</span></label>
           <div class="bulk-destination">
-            <select value={bulkFolderId} aria-label="Destination collection" on:change={(event) => onSetBulkFolderId(event.currentTarget.value)}>
-              <option value="">Unfiled</option>
-              {#each folders as folder (folder.id)}<option value={folder.id}>{folder.name}</option>{/each}
-            </select>
+            <div class="sort-control" bind:this={folderContainer}>
+              <button
+                bind:this={folderButton}
+                type="button"
+                class="sort-select-trigger"
+                aria-haspopup="listbox"
+                aria-expanded={folderMenuOpen}
+                aria-label="Destination collection"
+                on:click={() => (folderMenuOpen = !folderMenuOpen)}
+                on:keydown={handleFolderTriggerKeydown}
+              >
+                <span>{bulkFolderLabel}</span>
+                <svg viewBox="0 0 12 12" aria-hidden="true"><path d="M2.5 4.5 6 8l3.5-3.5" /></svg>
+              </button>
+              {#if folderMenuOpen}
+                <div class="sort-menu" role="listbox" aria-label="Destination collection">
+                  <button type="button" class:selected={!bulkFolderId} role="option" aria-selected={!bulkFolderId} tabindex="-1" on:click={() => chooseBulkFolder('')} on:keydown={handleFolderOptionKeydown}>Unfiled</button>
+                  {#each folders as folder (folder.id)}
+                    <button type="button" class:selected={bulkFolderId === folder.id} role="option" aria-selected={bulkFolderId === folder.id} tabindex="-1" on:click={() => chooseBulkFolder(folder.id)} on:keydown={handleFolderOptionKeydown}>{folder.name}</button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
             <button type="button" class="secondary-button bulk-move-button" disabled={!selectedIds.length} on:click={onBulkMove}>Move</button>
           </div>
           <div class="bulk-toolbar-actions">

--- a/tools/browser-protocol-contracts.test.mjs
+++ b/tools/browser-protocol-contracts.test.mjs
@@ -70,6 +70,12 @@ test('card protocol v2 is HTTPS-only, card-only, and regression-vectored', () =>
   ])
   assert.equal(requestSchema.properties.origin.pattern, '^https://[^/]+$')
   assert.ok(contract.responseTypes.includes('error'))
+
+  const cardResponse = responseSchema.oneOf.find((branch) => branch.properties.type.const === 'card')
+  assert.deepEqual(cardResponse.required, ['version', 'type', 'requestId', 'card'])
+  assert.equal(cardResponse.additionalProperties, false)
+  assert.equal(cardResponse.properties.card.additionalProperties, false)
+  assert.deepEqual(Object.keys(cardResponse.properties.card.properties), contract.cardFieldKeys)
   assert.equal(vectors.protocolVersion, contract.protocolVersion)
   assert.equal(vectors.fictionalDataOnly, true)
   assert.ok(


### PR DESCRIPTION
## Summary

- replace the last native selects with the app's own listbox, so no menu is drawn by the operating system in the dark theme
- slide one shared marker between segmented options instead of repainting whichever button the pointer landed on
- open the dropdowns with a short animation, style the scrollbars inside modals and menus, and keep the focus ring for keyboard focus only
- assert the card response schema in the protocol contract test, which was being loaded and never checked

## Interface consistency

There are now no `<select>` elements left in `src/`. Three pickers still had one: the login editor's folder, the item detail's collection, and the custom record field kind. Each carried its own styling, and two of them broke when converted because the CSS still targeted `select`.

All three now take the same rule that already styles the editor fields, so a picker matches the inputs beside it rather than carrying a copy of their styling. `.custom-field-kind` and the dead `.bulk-toolbar select` rules are gone: the shared styles cover both.

## Validation

- `npm run lint:js`: 0 errors, 1 pre-existing warning in `RecoveryKitScreen.svelte`, which this branch does not touch
- `npm run desktop:check`: 270 files, 0 errors, 0 warnings; 19 unit tests pass
- `npm run contracts`: 48 tests pass

The new card response assertion was checked against a mutated schema: adding an undeclared property to the card branch fails the test (47 pass, 1 fail), and the schema was restored.

## Manual verification

Driven through the real interface with Playwright against the dev server, measuring computed geometry rather than reading the CSS:

| control | sibling field | converted picker |
| --- | --- | --- |
| login editor folder | 594x39, 13px, weight 700 | 594x39, 13px, weight 700 |
| item detail collection | row 650 wide | 579 + 8 gap + 63 delete = 650 |
| custom record kind | 39px, 13px, weight 400 | 39px, 13px, weight 400 |

Colours, background, and `10px 11px` padding match in all three.
