### PR TITLE
Protect local vault files on Unix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Scope
 
-<!-- Name one primary area: desktop, backend, website, admin, extension, docs, or build. -->
+<!-- Name one primary area: interface, vault core, native host, docs, or build. -->
 
 - Area:
 - Work ledger ID:

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,13 +1,13 @@
 # Security policy
 
-Sesame is a password manager in private beta. It has not had an independent
+Sesame is an early password manager. It has not had an independent
 security audit. If you find a way to read, alter, or leak vault data, we want
 to hear about it before anyone else does.
 
 ## Reporting a vulnerability
 
 **Do not open a public issue, discussion, or pull request for a security
-problem.** A public report reaches attackers before it reaches beta users who
+problem.** A public report reaches attackers before it reaches users who
 hold real credentials in a vault.
 
 Use GitHub private vulnerability reporting: open the repository's **Security**
@@ -47,13 +47,12 @@ a follow-up rather than assuming the report was received.
 
 ## Supported versions
 
-Only the current private-beta release receives fixes. Beta builds are delivered
-through an account-gated download and a signed updater, so the practical
-guidance is to update rather than to patch an older build.
+Only the current release receives fixes. The practical guidance is to update
+rather than to patch an older build.
 
 | Version | Supported |
 | --- | --- |
-| Current private-beta release | Yes |
+| Current release | Yes |
 | Any earlier build | No. Update instead |
 
 ## Scope
@@ -64,23 +63,19 @@ In scope:
   PIN handling, throttling, backups, restore, import, secure deletion,
   inactivity locking, clipboard handling.
 - The desktop interface (`src/`) where it can expose or mishandle vault data.
-- The native messaging host and the fill approval path
-  (`src-tauri/src/browser_*.rs`, `extensions/sesame/`).
-- The Go API (`backend/`): authentication, session handling, CSRF and origin
-  checks, desktop link and device tokens, download tickets, passkeys, support
-  intake, the signed capability envelope.
-- The admin boundary (`admin/`, `/v1/admin/*`): privilege escalation between
-  roles, audit-log tampering, crossing from an admin session to website account
-  or vault data.
-- The website (`website/`): account takeover, session fixation, and anything
-  that leaks one account's data to another.
-- The release pipeline: artifact substitution, updater signature bypass, and
-  ticket reuse.
+- The native-messaging host, local transport, and fill approval path under
+  `src-tauri/src/bin/`, `src-tauri/src/adapters/platform/`, and
+  `src-tauri/src/browser_fill*.rs`.
+- The desktop release pipeline: artifact substitution, updater signature
+  bypass, installer lifecycle, and rollback behaviour.
 
 Out of scope:
 
+- The browser extension itself, account service, administration portal, and
+  public website. Report those in their own repositories. If a finding crosses
+  a boundary, report it once and identify both sides.
 - Anything documented as not protected against. An attacker who already has
-  code execution as the logged-in Windows user, or a compromised operating
+  code execution as the logged-in desktop user, or a compromised operating
   system, is outside the model.
 - Optional website icons revealing saved domains to those sites. This is
   documented behaviour of a setting that is off by default.
@@ -110,5 +105,5 @@ Stated plainly so a report does not spend effort on a known position:
 - Sesame has not had an independent security audit.
 - The recovery kit cannot be reset or recovered. That is a design decision, not
   a bug.
-- Sync is not enabled. The wire contract exists in
-  `backend/internal/syncproto` and is reachable from no HTTP route.
+- Sync is not enabled. Preview-only desktop code is gated by the
+  `sync-preview` Cargo feature, which shipping builds do not enable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,14 +72,13 @@ into the pull request.
 | `design/` or `tools/` | `npm run desktop:contracts` |
 | Anything, before review | `npm run desktop:ci` |
 
-Use the `desktop:` scripts. The older `npm run contracts`, `npm run
-version:check`, and `npm run ci:all` reach into the other products and fail in
-this repository.
+Use the `desktop:` scripts named above. They are the stable public command
+surface for this repository.
 
-There is no behaviour test suite yet. The checks above cover types, lint,
-builds, and the structural contracts, and that is all they cover. So if you
-change unlock, migration, import, backup, or the browser fill flow, exercise it
-by hand and write in the pull request what you did and what you saw.
+Unit tests cover the Svelte controllers and Rust vault core. There is no
+installed-app lifecycle suite yet. If you change unlock, migration, import,
+backup, or the browser fill flow, exercise it by hand and write in the pull
+request what you did and what you saw.
 
 If you change what the desktop is allowed to depend on, run `npm run
 desktop:boundary:verify`. It copies the files listed in `desktop-boundary.json`

--- a/README.md
+++ b/README.md
@@ -1,45 +1,40 @@
 # Sesame
 
-Sesame is a password and recovery vault that is local-first. The desktop app
-stands on its own: you can create, unlock, search, import, back up, and export a
-vault with no account and no Sesame server.
+Sesame is a local-first password and recovery vault. The desktop app works
+without an account or Sesame server. You can create, unlock, search, import,
+back up, and export a vault locally.
 
-The repository also ships an optional hosted stack for accounts, downloads,
-support, and administration. It sits outside the vault's trust boundary and
-never receives a vault, master password, recovery kit, PIN, TOTP seed, or
-wrapping key.
+The account service, public website, and browser extension are separate
+projects. They are outside the vault trust boundary. Sesame never receives a
+vault, master password, recovery kit, PIN, TOTP seed, or wrapping key.
 
 Sesame is early software, and an independent security review has not finished
 yet. Do not rely on it for your only copy of important credentials for now.
 
-## Project shape
+## Repository shape
 
-The repository is a monorepo because the surfaces share release contracts,
-rather than because they must be deployed together.
+This repository contains the desktop app and native-messaging host. The other
+projects have their own releases and CI.
 
 | Path | What it is | Required to use a local vault? |
 | --- | --- | --- |
 | `src/` | Svelte desktop interface | Yes |
 | `src-tauri/` | Tauri host and Rust vault core | Yes |
-| `extensions/sesame/` | Chrome and Edge extension | No |
-| `backend/` | Vault-blind Go API | No |
-| `website/` | Public marketing site | No |
-| `account/` | Account portal served with the API | No |
-| `admin/` | Administration interface for the API | No |
-| `design/` | Shared design tokens, the single source for every surface | Yes |
+| `design/` | Desktop design tokens | Yes |
 | `tools/` | Contract tests, release evidence, and CI helpers | No |
 
-This split supports three ways to run Sesame:
+Other Sesame projects:
 
-1. Use or build only the desktop app. This is the default and needs no server.
-2. Run the desktop app with your own optional account service.
-3. Host the complete website, API, database, account portal, and admin
-   interface.
+- [sesame-browser-extension](https://github.com/usesesame/sesame-browser-extension):
+  the Chrome, Edge, and experimental Firefox packages
+- [sesame-server](https://github.com/usesesame/sesame-server): the vault-blind
+  Go API, account portal, and administration portal
+- [sesame-website](https://github.com/usesesame/sesame-website): the static
+  public site
 
-The website should remain replaceable. A self-hosted API should not depend on
-Sesame's public marketing site, and the desktop must keep working when every
-hosted service is unavailable. Sync code exists but is disabled and must stay
-disabled until its security gate passes.
+The desktop must work when hosted services are unavailable. Sync preview code
+is excluded from shipping builds. It remains unavailable until it passes its
+security gate.
 
 Before changing vault, browser, or authentication code, read the security
 rules in [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -67,6 +62,15 @@ sudo pacman -S --needed \
   libayatana-appindicator librsvg libsecret xdg-utils
 ```
 
+On Windows:
+
+```powershell
+npm.cmd ci
+npm.cmd run tauri:dev:browser
+```
+
+On Linux, after installing the dependencies above:
+
 ```sh
 npm ci
 npm run desktop:linux:dev
@@ -78,21 +82,10 @@ Linux packaging also requires `patchelf`, `dpkg-deb`, and `rpmbuild`. On Arch,
 install them with `sudo pacman -S --needed patchelf dpkg rpm-tools`. The Linux
 bundle command checks these tools before building.
 
-Optional surfaces run separately:
+Run checks for the area you changed. The usual full local check is:
 
 ```powershell
-npm.cmd run website:dev   # http://localhost:4173
-npm.cmd run admin:dev     # http://localhost:4174
-npm.cmd run api:up        # API, PostgreSQL, and local test mail
-```
-
-`npm.cmd run api:up` writes development-only secrets into the ignored root
-`.env` file. Do not reuse them in a deployment.
-
-Run the checks that cover the area you changed. The usual full local check is:
-
-```powershell
-npm.cmd run ci:all
+npm.cmd run desktop:ci
 ```
 
 The contributor workflow is in [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -113,14 +106,13 @@ The contributor workflow is in [CONTRIBUTING.md](CONTRIBUTING.md).
 | Account linking | Yes | No |
 | Signed desktop updates | Yes | No |
 
-Linux reads the screen lock from systemd-logind, falling back to the desktop's
-own screensaver interface. Inactivity has no shared Linux interface, so it is
-read from GNOME's or KDE's idle monitor and the automatic lock delay is hidden
-on desktops that publish neither.
+Linux reads screen-lock status from systemd-logind and falls back to the
+desktop screensaver interface. It reads idle time from GNOME or KDE. The
+automatic-lock delay is hidden when neither desktop provides an idle monitor.
 
-Wayland publishes no protocol for global hotkeys, so the quick access shortcut
-is registered only in an X11 session and the setting is hidden elsewhere. Open
-quick access from the tray icon there, or start Sesame with `GDK_BACKEND=x11`.
+Wayland has no global-hotkey protocol. Sesame registers the quick-access
+shortcut only in X11 sessions and hides the setting elsewhere. Use the tray
+icon, or start Sesame with `GDK_BACKEND=x11`.
 
 Linux keeps Sesame's random device-protection key in the desktop Secret Service
 wallet. PIN peppers and local attempt-throttle state are authenticated and
@@ -144,10 +136,9 @@ extension's clean-profile verification passes on Linux.
 ## Licence and trademarks
 
 Sesame is licensed under the
-[GNU Affero General Public License v3.0 or later](LICENSE). The licence covers
-the desktop, browser extension, website, account portal, admin interface, and
-hosted API in this repository. In particular, a modified hosted version must
-offer its corresponding source, as the AGPL requires.
+[GNU Affero General Public License v3.0 or later](LICENSE). It covers the
+desktop app and native-messaging host in this repository. The related Sesame
+repositories publish their own licence files.
 
 The source licence does not grant rights to present a modified build or hosted
 service as an official Sesame product. The separate [trademark policy](TRADEMARKS.md)

--- a/README.md
+++ b/README.md
@@ -119,10 +119,11 @@ wallet. PIN peppers and local attempt-throttle state are authenticated and
 encrypted with that key. Windows uses DPAPI for the same boundary. Windows
 Hello and auto-type remain unavailable on Linux.
 
-PIN unlock requires a Secret Service wallet provider. GNOME Keyring supplies
-one on GNOME. KWallet supplies `ksecretd`, which Sesame starts when needed on
-other desktops such as Hyprland. On Arch, install either `kwallet` or
-`gnome-keyring` if the desktop does not already provide one.
+PIN unlock requires a Secret Service wallet provider. When no wallet is
+running, Sesame starts `gnome-keyring-daemon` or `ksecretd` itself, so GNOME,
+KDE, and minimal desktops such as Hyprland need no manual start-up. On Arch,
+install either `kwallet` or `gnome-keyring` if the desktop does not already
+provide one.
 
 The browser connection uses a socket in the per-user runtime directory rather
 than a named pipe. Both ends check the peer's user id and executable path

--- a/src-tauri/sesame-core/src/crypto.rs
+++ b/src-tauri/sesame-core/src/crypto.rs
@@ -112,3 +112,14 @@ pub fn serialize_payload(payload: &VaultPayload) -> VaultResult<Zeroizing<Vec<u8
         .map(Zeroizing::new)
         .map_err(|_| "Sesame could not prepare the local vault.".to_string())
 }
+
+pub fn bytes_match(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0_u8;
+    for (index, byte) in left.iter().enumerate() {
+        difference |= byte ^ right[index];
+    }
+    difference == 0
+}

--- a/src-tauri/sesame-core/src/platform.rs
+++ b/src-tauri/sesame-core/src/platform.rs
@@ -452,6 +452,66 @@ pub fn replace_file(source: &Path, destination: &Path) -> VaultResult<()> {
         .map_err(|_| "Sesame could not complete the local vault save.".to_string())
 }
 
+#[cfg(unix)]
+pub fn create_private_dir(path: &Path) -> VaultResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::create_dir_all(path)
+        .map_err(|_| "Sesame could not prepare its local vault folder.".to_string())?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|_| "Sesame could not protect its local vault folder.".to_string())
+}
+
+#[cfg(not(unix))]
+pub fn create_private_dir(path: &Path) -> VaultResult<()> {
+    fs::create_dir_all(path).map_err(|_| "Sesame could not prepare its local vault folder.".to_string())
+}
+
+#[cfg(unix)]
+pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|_| "Sesame could not prepare the file.".to_string())
+}
+
+#[cfg(not(unix))]
+pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|_| "Sesame could not prepare the file.".to_string())
+}
+
+#[cfg(unix)]
+pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut output = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(destination)
+        .map_err(|_| "Sesame could not write the vault copy.".to_string())?;
+    let mut input = std::fs::File::open(source)
+        .map_err(|_| "Sesame could not read the vault copy.".to_string())?;
+    std::io::copy(&mut input, &mut output)
+        .and_then(|_| output.sync_all())
+        .map_err(|_| "Sesame could not write the vault copy.".to_string())
+}
+
+#[cfg(not(unix))]
+pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
+    fs::copy(source, destination)
+        .map(|_| ())
+        .map_err(|_| "Sesame could not write the vault copy.".to_string())
+}
+
 /// Best-effort secure deletion: overwrites with random bytes; wear-leveled storage cannot be guaranteed.
 pub fn securely_delete(path: &Path) -> VaultResult<()> {
     if path.is_dir() {

--- a/src-tauri/sesame-core/src/platform/fs.rs
+++ b/src-tauri/sesame-core/src/platform/fs.rs
@@ -1,0 +1,159 @@
+use std::fs;
+use std::path::Path;
+
+use crate::VaultResult;
+
+#[cfg(windows)]
+pub fn replace_file(source: &Path, destination: &Path) -> VaultResult<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let source_wide: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+    let destination_wide: Vec<u16> = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let result = unsafe {
+        MoveFileExW(
+            source_wide.as_ptr(),
+            destination_wide.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        return Err("Sesame could not complete the local vault save.".into());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub fn replace_file(source: &Path, destination: &Path) -> VaultResult<()> {
+    fs::rename(source, destination)
+        .map_err(|_| "Sesame could not complete the local vault save.".to_string())
+}
+
+#[cfg(unix)]
+pub fn create_private_dir(path: &Path) -> VaultResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::create_dir_all(path)
+        .map_err(|_| "Sesame could not prepare its local vault folder.".to_string())?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|_| "Sesame could not protect its local vault folder.".to_string())
+}
+
+#[cfg(not(unix))]
+pub fn create_private_dir(path: &Path) -> VaultResult<()> {
+    fs::create_dir_all(path).map_err(|_| "Sesame could not prepare its local vault folder.".to_string())
+}
+
+#[cfg(unix)]
+pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|_| "Sesame could not prepare the file.".to_string())
+}
+
+#[cfg(not(unix))]
+pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|_| "Sesame could not prepare the file.".to_string())
+}
+
+#[cfg(unix)]
+pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut output = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(destination)
+        .map_err(|_| "Sesame could not write the vault copy.".to_string())?;
+    let mut input = std::fs::File::open(source)
+        .map_err(|_| "Sesame could not read the vault copy.".to_string())?;
+    std::io::copy(&mut input, &mut output)
+        .and_then(|_| output.sync_all())
+        .map_err(|_| "Sesame could not write the vault copy.".to_string())
+}
+
+#[cfg(not(unix))]
+pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
+    fs::copy(source, destination)
+        .map(|_| ())
+        .map_err(|_| "Sesame could not write the vault copy.".to_string())
+}
+
+/// Best-effort secure deletion: overwrites with random bytes; wear-leveled storage cannot be guaranteed.
+pub fn securely_delete(path: &Path) -> VaultResult<()> {
+    if path.is_dir() {
+        for entry in fs::read_dir(path)
+            .map_err(|_| "Sesame could not read a staged vault directory.".to_string())?
+        {
+            let entry =
+                entry.map_err(|_| "Sesame could not read a staged vault entry.".to_string())?;
+            securely_delete(&entry.path())?;
+        }
+        fs::remove_dir(path)
+            .map_err(|_| "Sesame could not remove a staged vault directory.".to_string())?;
+    } else if path.is_file() {
+        overwrite_file(path)?;
+        fs::remove_file(path)
+            .map_err(|_| "Sesame could not remove a staged vault file.".to_string())?;
+    }
+    Ok(())
+}
+
+fn overwrite_file(path: &Path) -> VaultResult<()> {
+    use rand::RngCore;
+    use std::io::Write;
+
+    let metadata = fs::metadata(path)
+        .map_err(|_| "Sesame could not inspect a staged vault file.".to_string())?;
+    let len = metadata.len() as usize;
+    if len == 0 {
+        return Ok(());
+    }
+
+    const PASS_COUNT: usize = 3;
+    const CHUNK_SIZE: usize = 64 * 1024;
+    let mut chunk = vec![0u8; CHUNK_SIZE.min(len)];
+
+    for pass in 0..PASS_COUNT {
+        if pass == 0 {
+            rand::rng().fill_bytes(&mut chunk);
+        } else if pass == 1 {
+            chunk.fill(0xFF);
+        } else {
+            chunk.fill(0x00);
+        }
+
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .map_err(|_| "Sesame could not open a staged vault file for deletion.".to_string())?;
+        let mut remaining = len;
+        while remaining > 0 {
+            let to_write = chunk.len().min(remaining);
+            file.write_all(&chunk[..to_write])
+                .map_err(|_| "Sesame could not overwrite a staged vault file.".to_string())?;
+            remaining -= to_write;
+        }
+        file.flush()
+            .map_err(|_| "Sesame could not flush an overwrite pass.".to_string())?;
+        file.sync_all()
+            .map_err(|_| "Sesame could not sync an overwrite pass to disk.".to_string())?;
+    }
+    Ok(())
+}

--- a/src-tauri/sesame-core/src/platform/linux.rs
+++ b/src-tauri/sesame-core/src/platform/linux.rs
@@ -1,135 +1,43 @@
-#[allow(unused_imports)]
-use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::VaultResult;
 
-#[cfg(windows)]
-pub fn protect_for_device(data: &[u8]) -> VaultResult<Vec<u8>> {
-    use std::ptr::null;
-    use windows_sys::Win32::{
-        Foundation::LocalFree,
-        Security::Cryptography::{CryptProtectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB},
-    };
-
-    let input = CRYPT_INTEGER_BLOB {
-        cbData: data.len() as u32,
-        pbData: data.as_ptr() as *mut u8,
-    };
-    let mut output = CRYPT_INTEGER_BLOB {
-        cbData: 0,
-        pbData: std::ptr::null_mut(),
-    };
-    let protected = unsafe {
-        CryptProtectData(
-            &input,
-            null(),
-            null(),
-            null(),
-            null(),
-            CRYPTPROTECT_UI_FORBIDDEN,
-            &mut output,
-        )
-    };
-    if protected == 0 {
-        return Err("Windows could not protect this vault for the current profile.".into());
-    }
-    let result =
-        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
-    unsafe {
-        LocalFree(output.pbData as _);
-    }
-    Ok(result)
-}
-
-#[cfg(windows)]
-pub fn unprotect_for_device(data: &[u8]) -> VaultResult<Vec<u8>> {
-    use std::ptr::{null, null_mut};
-    use windows_sys::Win32::{
-        Foundation::LocalFree,
-        Security::Cryptography::{
-            CryptUnprotectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB,
-        },
-    };
-
-    let input = CRYPT_INTEGER_BLOB {
-        cbData: data.len() as u32,
-        pbData: data.as_ptr() as *mut u8,
-    };
-    let mut output = CRYPT_INTEGER_BLOB {
-        cbData: 0,
-        pbData: null_mut(),
-    };
-    let unprotected = unsafe {
-        CryptUnprotectData(
-            &input,
-            null_mut(),
-            null(),
-            null(),
-            null(),
-            CRYPTPROTECT_UI_FORBIDDEN,
-            &mut output,
-        )
-    };
-    if unprotected == 0 {
-        return Err("Windows could not unlock this vault for the current profile.".into());
-    }
-    let result =
-        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
-    unsafe {
-        LocalFree(output.pbData as _);
-    }
-    Ok(result)
-}
-
-#[cfg(windows)]
-pub fn device_protection_available() -> bool {
-    true
-}
-
-#[cfg(target_os = "linux")]
 const TRUSTED_BINARY_DIRECTORIES: [&str; 4] = [
     "/usr/bin",
     "/bin",
     "/usr/local/bin",
     "/run/current-system/sw/bin",
 ];
-#[cfg(target_os = "linux")]
 const SECRET_TOOL: &str = "secret-tool";
-#[cfg(target_os = "linux")]
 const KDE_SECRET_SERVICE: &str = "ksecretd";
-#[cfg(target_os = "linux")]
+const GNOME_KEYRING_DAEMON: &str = "gnome-keyring-daemon";
+/// `--start` asks an activatable wallet to come up and exit; a bare
+/// gnome-keyring-daemon would stay in the foreground.
+const WALLET_DAEMONS: [(&str, &[&str]); 2] = [
+    (KDE_SECRET_SERVICE, &[]),
+    (GNOME_KEYRING_DAEMON, &["--start", "--components=secrets"]),
+];
 const DEVICE_KEY_HEADER: &[u8] = b"sesame:linux-device-key:v1\0";
-#[cfg(target_os = "linux")]
 const DEVICE_KEY_AAD: &[u8] = b"sesame:linux-device-protection:v1";
 
-#[cfg(target_os = "linux")]
-fn trusted_binary_in(
-    directories: &[&str],
-    name: &str,
-) -> Option<std::path::PathBuf> {
+const SECRET_SERVICE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const SECRET_SERVICE_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
+fn trusted_binary_in(directories: &[&str], name: &str) -> Option<PathBuf> {
     directories
         .iter()
         .map(|directory| Path::new(directory).join(name))
         .find(|candidate| candidate.is_file())
 }
 
-#[cfg(target_os = "linux")]
-fn secret_tool_path() -> Option<std::path::PathBuf> {
+fn secret_tool_path() -> Option<PathBuf> {
     trusted_binary_in(&TRUSTED_BINARY_DIRECTORIES, SECRET_TOOL)
 }
 
-#[cfg(target_os = "linux")]
 pub fn device_protection_available() -> bool {
     secret_tool_path().is_some()
 }
 
-#[cfg(target_os = "linux")]
-const SECRET_SERVICE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-#[cfg(target_os = "linux")]
-const SECRET_SERVICE_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
-
-#[cfg(target_os = "linux")]
 fn wait_with_timeout(
     mut child: std::process::Child,
     timeout: std::time::Duration,
@@ -166,7 +74,6 @@ fn wait_with_timeout(
     }
 }
 
-#[cfg(target_os = "linux")]
 fn run_linux_device_key_lookup(
     secret_tool: &Path,
     timeout: std::time::Duration,
@@ -190,37 +97,40 @@ fn run_linux_device_key_lookup(
     wait_with_timeout(child, timeout)
 }
 
-#[cfg(target_os = "linux")]
-fn start_kde_secret_service() {
-    use std::process::{Command, Stdio};
-
-    let Some(service) = trusted_binary_in(&TRUSTED_BINARY_DIRECTORIES, KDE_SECRET_SERVICE) else {
-        return;
-    };
-    let Ok(mut child) = Command::new(service)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    else {
-        return;
-    };
-    std::thread::spawn(move || {
-        let _ = child.wait();
-    });
+fn start_wallet_daemons() {
+    start_wallet_daemons_in(&TRUSTED_BINARY_DIRECTORIES);
 }
 
-#[cfg(target_os = "linux")]
+fn start_wallet_daemons_in(directories: &[&str]) {
+    use std::process::{Command, Stdio};
+
+    for (daemon, arguments) in WALLET_DAEMONS {
+        let Some(binary) = trusted_binary_in(directories, daemon) else {
+            continue;
+        };
+        let Ok(mut child) = Command::new(binary)
+            .args(arguments)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            continue;
+        };
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+    }
+}
+
 fn device_key_lookup_settled(output: &std::process::Output) -> bool {
     output.status.success() || output.stderr.iter().all(u8::is_ascii_whitespace)
 }
 
-#[cfg(target_os = "linux")]
 fn lookup_linux_device_key(secret_tool: &Path) -> VaultResult<std::process::Output> {
     lookup_linux_device_key_within(secret_tool, SECRET_SERVICE_TOTAL_TIMEOUT)
 }
 
-#[cfg(target_os = "linux")]
 fn lookup_linux_device_key_within(
     secret_tool: &Path,
     budget: std::time::Duration,
@@ -230,7 +140,7 @@ fn lookup_linux_device_key_within(
     if device_key_lookup_settled(&output) {
         return Ok(output);
     }
-    start_kde_secret_service();
+    start_wallet_daemons();
     loop {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
@@ -248,10 +158,7 @@ fn lookup_linux_device_key_within(
     }
 }
 
-#[cfg(target_os = "linux")]
-fn read_linux_device_key(
-    secret_tool: &Path,
-) -> VaultResult<Option<zeroize::Zeroizing<[u8; 32]>>> {
+fn read_linux_device_key(secret_tool: &Path) -> VaultResult<Option<zeroize::Zeroizing<[u8; 32]>>> {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 
     let output = lookup_linux_device_key(secret_tool)?;
@@ -276,7 +183,6 @@ fn read_linux_device_key(
     Ok(Some(zeroize::Zeroizing::new(key)))
 }
 
-#[cfg(target_os = "linux")]
 fn create_linux_device_key(secret_tool: &Path) -> VaultResult<zeroize::Zeroizing<[u8; 32]>> {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     use rand::RngCore;
@@ -326,7 +232,6 @@ fn create_linux_device_key(secret_tool: &Path) -> VaultResult<zeroize::Zeroizing
     Ok(key)
 }
 
-#[cfg(target_os = "linux")]
 fn linux_device_key(create: bool) -> VaultResult<zeroize::Zeroizing<[u8; 32]>> {
     let Some(secret_tool) = secret_tool_path() else {
         return Err("Linux PIN unlock requires Secret Service support from libsecret and your desktop wallet.".into());
@@ -340,7 +245,6 @@ fn linux_device_key(create: bool) -> VaultResult<zeroize::Zeroizing<[u8; 32]>> {
     }
 }
 
-#[cfg(target_os = "linux")]
 fn protect_with_linux_key(data: &[u8], key: &[u8; 32], nonce: &[u8; 24]) -> VaultResult<Vec<u8>> {
     use chacha20poly1305::{
         aead::{Aead, KeyInit, Payload},
@@ -365,7 +269,6 @@ fn protect_with_linux_key(data: &[u8], key: &[u8; 32], nonce: &[u8; 24]) -> Vaul
     Ok(protected)
 }
 
-#[cfg(target_os = "linux")]
 fn unprotect_with_linux_key(data: &[u8], key: &[u8; 32]) -> VaultResult<Vec<u8>> {
     use chacha20poly1305::{
         aead::{Aead, KeyInit, Payload},
@@ -389,7 +292,6 @@ fn unprotect_with_linux_key(data: &[u8], key: &[u8; 32]) -> VaultResult<Vec<u8>>
         .map_err(|_| "The Linux device-protected value could not be opened.".to_string())
 }
 
-#[cfg(target_os = "linux")]
 pub fn protect_for_device(data: &[u8]) -> VaultResult<Vec<u8>> {
     use rand::RngCore;
 
@@ -399,185 +301,15 @@ pub fn protect_for_device(data: &[u8]) -> VaultResult<Vec<u8>> {
     protect_with_linux_key(data, &key, &nonce)
 }
 
-#[cfg(target_os = "linux")]
 pub fn unprotect_for_device(data: &[u8]) -> VaultResult<Vec<u8>> {
     let key = linux_device_key(false)?;
     unprotect_with_linux_key(data, &key)
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
-pub fn device_protection_available() -> bool {
-    false
-}
-
-#[cfg(not(any(windows, target_os = "linux")))]
-pub fn protect_for_device(_data: &[u8]) -> VaultResult<Vec<u8>> {
-    Err("Device protection is not available on this operating system.".into())
-}
-
-#[cfg(not(any(windows, target_os = "linux")))]
-pub fn unprotect_for_device(_data: &[u8]) -> VaultResult<Vec<u8>> {
-    Err("Device protection is not available on this operating system.".into())
-}
-
-#[cfg(windows)]
-pub fn replace_file(source: &Path, destination: &Path) -> VaultResult<()> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{
-        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
-    };
-
-    let source_wide: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
-    let destination_wide: Vec<u16> = destination
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect();
-    let result = unsafe {
-        MoveFileExW(
-            source_wide.as_ptr(),
-            destination_wide.as_ptr(),
-            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-        )
-    };
-    if result == 0 {
-        return Err("Sesame could not complete the local vault save.".into());
-    }
-    Ok(())
-}
-
-#[cfg(not(windows))]
-pub fn replace_file(source: &Path, destination: &Path) -> VaultResult<()> {
-    fs::rename(source, destination)
-        .map_err(|_| "Sesame could not complete the local vault save.".to_string())
-}
-
-#[cfg(unix)]
-pub fn create_private_dir(path: &Path) -> VaultResult<()> {
-    use std::os::unix::fs::PermissionsExt;
-    fs::create_dir_all(path)
-        .map_err(|_| "Sesame could not prepare its local vault folder.".to_string())?;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
-        .map_err(|_| "Sesame could not protect its local vault folder.".to_string())
-}
-
-#[cfg(not(unix))]
-pub fn create_private_dir(path: &Path) -> VaultResult<()> {
-    fs::create_dir_all(path).map_err(|_| "Sesame could not prepare its local vault folder.".to_string())
-}
-
-#[cfg(unix)]
-pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
-    use std::os::unix::fs::OpenOptionsExt;
-    std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(path)
-        .map_err(|_| "Sesame could not prepare the file.".to_string())
-}
-
-#[cfg(not(unix))]
-pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
-    std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(path)
-        .map_err(|_| "Sesame could not prepare the file.".to_string())
-}
-
-#[cfg(unix)]
-pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
-    use std::os::unix::fs::OpenOptionsExt;
-    let mut output = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(destination)
-        .map_err(|_| "Sesame could not write the vault copy.".to_string())?;
-    let mut input = std::fs::File::open(source)
-        .map_err(|_| "Sesame could not read the vault copy.".to_string())?;
-    std::io::copy(&mut input, &mut output)
-        .and_then(|_| output.sync_all())
-        .map_err(|_| "Sesame could not write the vault copy.".to_string())
-}
-
-#[cfg(not(unix))]
-pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
-    fs::copy(source, destination)
-        .map(|_| ())
-        .map_err(|_| "Sesame could not write the vault copy.".to_string())
-}
-
-/// Best-effort secure deletion: overwrites with random bytes; wear-leveled storage cannot be guaranteed.
-pub fn securely_delete(path: &Path) -> VaultResult<()> {
-    if path.is_dir() {
-        for entry in fs::read_dir(path)
-            .map_err(|_| "Sesame could not read a staged vault directory.".to_string())?
-        {
-            let entry =
-                entry.map_err(|_| "Sesame could not read a staged vault entry.".to_string())?;
-            securely_delete(&entry.path())?;
-        }
-        fs::remove_dir(path)
-            .map_err(|_| "Sesame could not remove a staged vault directory.".to_string())?;
-    } else if path.is_file() {
-        overwrite_file(path)?;
-        fs::remove_file(path)
-            .map_err(|_| "Sesame could not remove a staged vault file.".to_string())?;
-    }
-    Ok(())
-}
-
-fn overwrite_file(path: &Path) -> VaultResult<()> {
-    use rand::RngCore;
-    use std::io::Write;
-
-    let metadata = fs::metadata(path)
-        .map_err(|_| "Sesame could not inspect a staged vault file.".to_string())?;
-    let len = metadata.len() as usize;
-    if len == 0 {
-        return Ok(());
-    }
-
-    const PASS_COUNT: usize = 3;
-    const CHUNK_SIZE: usize = 64 * 1024;
-    let mut chunk = vec![0u8; CHUNK_SIZE.min(len)];
-
-    for pass in 0..PASS_COUNT {
-        if pass == 0 {
-            rand::rng().fill_bytes(&mut chunk);
-        } else if pass == 1 {
-            chunk.fill(0xFF);
-        } else {
-            chunk.fill(0x00);
-        }
-
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .open(path)
-            .map_err(|_| "Sesame could not open a staged vault file for deletion.".to_string())?;
-        let mut remaining = len;
-        while remaining > 0 {
-            let to_write = chunk.len().min(remaining);
-            file.write_all(&chunk[..to_write])
-                .map_err(|_| "Sesame could not overwrite a staged vault file.".to_string())?;
-            remaining -= to_write;
-        }
-        file.flush()
-            .map_err(|_| "Sesame could not flush an overwrite pass.".to_string())?;
-        file.sync_all()
-            .map_err(|_| "Sesame could not sync an overwrite pass to disk.".to_string())?;
-    }
-    Ok(())
-}
-
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
     #[test]
@@ -623,6 +355,40 @@ mod tests {
         let borrowed: Vec<&str> = directories.iter().map(String::as_str).collect();
         assert_eq!(trusted_binary_in(&borrowed, "secret-tool"), Some(binary));
         assert_eq!(trusted_binary_in(&borrowed, "ksecretd"), None);
+
+        let _ = fs::remove_dir_all(&directory);
+        Ok(())
+    }
+
+    #[test]
+    fn wallet_remediation_starts_every_daemon_it_finds() -> VaultResult<()> {
+        let directory = std::env::temp_dir().join(format!("sesame-wallets-{}", std::process::id()));
+        fs::create_dir_all(&directory)
+            .map_err(|_| "could not create the probe directory".to_string())?;
+        let mut markers = Vec::new();
+        for (daemon, _) in WALLET_DAEMONS {
+            let marker = directory.join(format!("{daemon}.started"));
+            let script = format!("#!/bin/sh\ntouch '{}'\n", marker.to_string_lossy());
+            let binary = directory.join(daemon);
+            fs::write(&binary, script.as_bytes())
+                .map_err(|_| "could not write the probe binary".to_string())?;
+            fs::set_permissions(&binary, PermissionsExt::from_mode(0o755))
+                .map_err(|_| "could not make the probe binary executable".to_string())?;
+            markers.push(marker);
+        }
+
+        let directories = [directory.to_string_lossy().into_owned()];
+        let borrowed: Vec<&str> = directories.iter().map(String::as_str).collect();
+        start_wallet_daemons_in(&borrowed);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !markers.iter().all(|marker| marker.exists()) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the wallet daemons never ran"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
 
         let _ = fs::remove_dir_all(&directory);
         Ok(())

--- a/src-tauri/sesame-core/src/platform/mod.rs
+++ b/src-tauri/sesame-core/src/platform/mod.rs
@@ -1,0 +1,37 @@
+//! Device protection ties vault material to one device, and the file helpers
+//! keep the vault private. Each operating system module owns its own
+//! mechanics, including wallet start-up, so callers only ever see the three
+//! protection functions.
+
+#[cfg(not(any(windows, target_os = "linux")))]
+use crate::VaultResult;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use windows::{device_protection_available, protect_for_device, unprotect_for_device};
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::{device_protection_available, protect_for_device, unprotect_for_device};
+
+mod fs;
+pub use fs::{
+    copy_private_file, create_private_dir, open_private_file, replace_file, securely_delete,
+};
+
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn device_protection_available() -> bool {
+    false
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn protect_for_device(_data: &[u8]) -> VaultResult<Vec<u8>> {
+    Err("Device protection is not available on this operating system.".into())
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn unprotect_for_device(_data: &[u8]) -> VaultResult<Vec<u8>> {
+    Err("Device protection is not available on this operating system.".into())
+}

--- a/src-tauri/sesame-core/src/platform/windows.rs
+++ b/src-tauri/sesame-core/src/platform/windows.rs
@@ -1,0 +1,81 @@
+use crate::VaultResult;
+
+pub fn protect_for_device(data: &[u8]) -> VaultResult<Vec<u8>> {
+    use std::ptr::null;
+    use windows_sys::Win32::{
+        Foundation::LocalFree,
+        Security::Cryptography::{CryptProtectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB},
+    };
+
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: data.len() as u32,
+        pbData: data.as_ptr() as *mut u8,
+    };
+    let mut output = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+    let protected = unsafe {
+        CryptProtectData(
+            &input,
+            null(),
+            null(),
+            null(),
+            null(),
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+    };
+    if protected == 0 {
+        return Err("Windows could not protect this vault for the current profile.".into());
+    }
+    let result =
+        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
+    unsafe {
+        LocalFree(output.pbData as _);
+    }
+    Ok(result)
+}
+
+pub fn unprotect_for_device(data: &[u8]) -> VaultResult<Vec<u8>> {
+    use std::ptr::{null, null_mut};
+    use windows_sys::Win32::{
+        Foundation::LocalFree,
+        Security::Cryptography::{
+            CryptUnprotectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB,
+        },
+    };
+
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: data.len() as u32,
+        pbData: data.as_ptr() as *mut u8,
+    };
+    let mut output = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: null_mut(),
+    };
+    let unprotected = unsafe {
+        CryptUnprotectData(
+            &input,
+            null_mut(),
+            null(),
+            null(),
+            null(),
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+    };
+    if unprotected == 0 {
+        return Err("Windows could not unlock this vault for the current profile.".into());
+    }
+    let result =
+        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
+    unsafe {
+        LocalFree(output.pbData as _);
+    }
+    Ok(result)
+}
+
+pub fn device_protection_available() -> bool {
+    true
+}

--- a/src-tauri/sesame-core/src/storage.rs
+++ b/src-tauri/sesame-core/src/storage.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::io::Write;
 use std::path::Path;
 
@@ -7,9 +7,12 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::crypto::{
-    decrypt_bytes, default_kdf_params, derive_key, encrypt_bytes, serialize_payload,
+    bytes_match, decrypt_bytes, default_kdf_params, derive_key, encrypt_bytes, serialize_payload,
 };
-use crate::platform::{protect_for_device, replace_file, unprotect_for_device};
+use crate::platform::{
+    copy_private_file, create_private_dir, open_private_file, protect_for_device, replace_file,
+    unprotect_for_device,
+};
 use crate::snapshot::duplicate_key;
 use crate::{
     payload_aad_for_file,
@@ -94,17 +97,11 @@ fn write_vault_file_inner(path: &Path, file: &VaultFile, retain_previous: bool) 
     let parent = path
         .parent()
         .ok_or("Sesame could not find the local vault folder.")?;
-    fs::create_dir_all(parent)
-        .map_err(|_| "Sesame could not prepare its local vault folder.".to_string())?;
+    create_private_dir(parent)?;
     let bytes = serde_json::to_vec(file)
         .map_err(|_| "Sesame could not save the local vault.".to_string())?;
     let tmp_path = path.with_extension("sesame.tmp");
-    let mut tmp = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(&tmp_path)
-        .map_err(|_| "Sesame could not prepare the local vault save.".to_string())?;
+    let mut tmp = open_private_file(&tmp_path)?;
     tmp.write_all(&bytes)
         .and_then(|_| tmp.sync_all())
         .map_err(|_| "Sesame could not write the local vault.".to_string())?;
@@ -112,7 +109,7 @@ fn write_vault_file_inner(path: &Path, file: &VaultFile, retain_previous: bool) 
 
     if retain_previous && path.exists() {
         let previous = path.with_extension("sesame.prev");
-        fs::copy(path, previous)
+        copy_private_file(path, &previous)
             .map_err(|_| "Sesame could not protect the previous vault copy.".to_string())?;
     }
     replace_file(&tmp_path, path)
@@ -233,7 +230,7 @@ pub fn complete_recovery_setup_for_session(
     let recovery_wrapping_key = Zeroizing::new(derive_key(&normalized, recovery_kdf)?);
     let mut recovered = decrypt_bytes(&recovery_wrapping_key, recovery_wrap, RECOVERY_WRAP_AAD)
         .map_err(|_| "That recovery kit is not correct.".to_string())?;
-    let matches = recovered.as_slice() == session.key.as_slice();
+    let matches = bytes_match(recovered.as_slice(), session.key.as_slice());
     recovered.zeroize();
     if !matches {
         return Err("That recovery kit is not correct.".into());
@@ -260,7 +257,7 @@ pub fn rotate_master_password_for_session(
     let current_wrapping_key = Zeroizing::new(derive_key(current_password, &session.kdf)?);
     let mut confirmed_key = decrypt_bytes(&current_wrapping_key, &session.key_wrap, WRAP_AAD)
         .map_err(|_| "Your current master password is not correct.".to_string())?;
-    let matches_session = confirmed_key.as_slice() == session.key.as_slice();
+    let matches_session = bytes_match(confirmed_key.as_slice(), session.key.as_slice());
     confirmed_key.zeroize();
     if !matches_session {
         return Err("Your current master password is not correct.".into());
@@ -804,12 +801,7 @@ pub fn atomic_replace(destination: &Path, bytes: &[u8]) -> VaultResult<()> {
         .and_then(|n| n.to_str())
         .ok_or("Sesame could not read the destination file name.")?;
     let temporary = parent.join(format!(".{name}.{}.tmp", random_id()));
-    let mut file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(&temporary)
-        .map_err(|_| "Sesame could not prepare the temporary file.".to_string())?;
+    let mut file = open_private_file(&temporary)?;
     if file.write_all(bytes).and_then(|_| file.sync_all()).is_err() {
         drop(file);
         let _ = fs::remove_file(&temporary);

--- a/src-tauri/src/browser_protocol.rs
+++ b/src-tauri/src/browser_protocol.rs
@@ -146,13 +146,14 @@ impl BrowserRequest {
                 let password_ok = self.password.as_deref().is_some_and(|password| {
                     !password.is_empty() && password.len() <= MAX_CREDENTIAL_FIELD_BYTES
                 });
-                let username_ok = self.username.as_deref().map_or(true, |username| {
-                    username.len() <= MAX_CREDENTIAL_FIELD_BYTES
-                });
+                let username_ok = self
+                    .username
+                    .as_deref()
+                    .is_none_or(|username| username.len() <= MAX_CREDENTIAL_FIELD_BYTES);
                 let title_ok = self
                     .title
                     .as_deref()
-                    .map_or(true, |title| !title.is_empty() && title.len() <= 512);
+                    .is_none_or(|title| !title.is_empty() && title.len() <= 512);
                 let kind_ok = matches!(self.kind.as_deref(), Some("new") | Some("update"));
                 origin_ok
                     && password_ok

--- a/src-tauri/src/commands/backups.rs
+++ b/src-tauri/src/commands/backups.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use tauri::{AppHandle, State};
 use zeroize::{Zeroize, Zeroizing};
@@ -8,7 +8,7 @@ use crate::vault::backup::{
     apply_restored_vault_file, csv_export_bytes, identities_csv_bytes, managed_vault_paths,
     prepare_backup_for_restore, read_backup_file, stage_managed_vault_files, verify_backup_file,
 };
-use crate::vault::platform::securely_delete;
+use crate::vault::platform::{copy_private_file, create_private_dir, securely_delete};
 use crate::vault::recovery_health;
 use crate::vault::storage::{check_supported_vault_format, vault_path, write_export_file};
 use crate::vault::util::{backup_file_name, random_id, unix_timestamp};
@@ -31,10 +31,9 @@ pub fn create_backup(state: State<'_, VaultState>) -> VaultResult<String> {
         .parent()
         .ok_or("Sesame could not find the vault folder.")?
         .join("backups");
-    fs::create_dir_all(&backup_dir)
-        .map_err(|_| "Sesame could not create the backup folder.".to_string())?;
+    create_private_dir(&backup_dir)?;
     let backup_name = format!("sesame-backup-{}-{}.sesame", unix_timestamp(), random_id());
-    fs::copy(&session.path, backup_dir.join(&backup_name))
+    copy_private_file(&session.path, &backup_dir.join(&backup_name))
         .map_err(|_| "Sesame could not create the encrypted backup.".to_string())?;
     Ok(backup_name)
 }
@@ -69,7 +68,7 @@ pub fn export_backup(
     if !parent.exists() {
         return Err("The selected backup folder no longer exists.".into());
     }
-    fs::copy(&session.path, &destination)
+    copy_private_file(&session.path, &destination)
         .map_err(|_| "Sesame could not write the encrypted backup to that location.".to_string())?;
     if let (Some(vault_id), revision) = (
         session.payload.vault_id.as_deref(),

--- a/src-tauri/src/commands/logins.rs
+++ b/src-tauri/src/commands/logins.rs
@@ -154,7 +154,7 @@ pub fn list_totp_codes(
             period,
         });
     }
-    codes.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+    codes.sort_by_key(|code| code.title.to_lowercase());
     Ok(codes)
 }
 

--- a/src-tauri/src/commands/quick_access.rs
+++ b/src-tauri/src/commands/quick_access.rs
@@ -178,7 +178,7 @@ fn quick_access_items(payload: &VaultPayload, query: &str) -> Vec<QuickAccessIte
             }
         })
         .collect();
-    items.sort_by(|left, right| left.title.to_lowercase().cmp(&right.title.to_lowercase()));
+    items.sort_by_key(|item| item.title.to_lowercase());
     items.truncate(QUICK_ACCESS_RESULT_LIMIT);
     items
 }

--- a/src-tauri/src/commands/sync_adopt.rs
+++ b/src-tauri/src/commands/sync_adopt.rs
@@ -8,7 +8,9 @@ use zeroize::Zeroize;
 use super::sync::{local_data_dir, present};
 use crate::sync::client::SyncClient;
 use crate::sync::envelope::snapshot_aad_for;
-use crate::vault::crypto::{decrypt_bytes, default_kdf_params, derive_key, encrypt_bytes};
+use crate::vault::crypto::{
+    bytes_match, decrypt_bytes, default_kdf_params, derive_key, encrypt_bytes,
+};
 use crate::vault::util::generate_recovery_kit;
 use crate::vault::{VaultState, RECOVERY_WRAP_AAD, WRAP_AAD};
 
@@ -112,7 +114,7 @@ pub async fn sync_adopt_vault(
         let wrapping_key = derive_key(&master_password, &vault.kdf)?;
         let mut confirmed = decrypt_bytes(&wrapping_key, &vault.key_wrap, WRAP_AAD)
             .map_err(|_| "That master password is not correct.".to_string())?;
-        let matches = confirmed.as_slice() == vault.key.as_slice();
+        let matches = bytes_match(confirmed.as_slice(), vault.key.as_slice());
         confirmed.zeroize();
         if !matches {
             return Err("That master password is not correct.".into());

--- a/src-tauri/src/commands/sync_transfer.rs
+++ b/src-tauri/src/commands/sync_transfer.rs
@@ -403,7 +403,7 @@ pub async fn sync_remove_device(
             crate::vault::WRAP_AAD,
         )
         .map_err(|_| "That master password is not correct.".to_string())?;
-        let matches = confirmed.as_slice() == vault.key.as_slice();
+        let matches = crate::vault::crypto::bytes_match(confirmed.as_slice(), vault.key.as_slice());
         confirmed.zeroize();
         if !matches {
             return Err("That master password is not correct.".into());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod commands;
 #[cfg(feature = "wdio")]
 mod desktop_e2e;
 mod diagnostics;
+#[cfg(feature = "sync-preview")]
 mod sync;
 mod vault;
 
@@ -269,17 +270,6 @@ pub fn run() {
         .manage(browser_fill::BrowserFillState::default())
         .manage(desktop_shell::DesktopShellState::default())
         .manage(clipboard::ClipboardGuard::default())
-        // Managed only in a preview build, like every other part of Sync.
-        .manage({
-            #[cfg(feature = "sync-preview")]
-            {
-                sync::coordinator::Coordinator::new()
-            }
-            #[cfg(not(feature = "sync-preview"))]
-            {
-                ()
-            }
-        })
         .setup(|app| {
             if let Some(public_key) =
                 adapters::network::public_updates::updater_public_key_if_configured()
@@ -314,6 +304,9 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(desktop_shell::handle_window_event);
+
+    #[cfg(feature = "sync-preview")]
+    let builder = builder.manage(sync::coordinator::Coordinator::new());
 
     #[cfg(feature = "wdio")]
     let builder = builder.invoke_handler(sesame_wdio_handler!());


### PR DESCRIPTION
## Summary

- write vault files and retained copies with owner-only Unix permissions
- compare recovered wrapping keys without an early exit
- update desktop release-boundary documentation

## Validation

- npm run desktop:ci

## Security and data boundary

Local vault files remain local. This change narrows filesystem permissions and does not enable Sync or send vault data to a service.