### PR TITLE
Open vault records one at a time behind a redacted index

### DIFF
--- a/src-tauri/sesame-core/src/history.rs
+++ b/src-tauri/sesame-core/src/history.rs
@@ -6,6 +6,7 @@ use crate::types::{
 };
 use crate::util::{random_id, unix_timestamp};
 use crate::VaultResult;
+use zeroize::Zeroize;
 
 pub const HISTORY_RETENTION_SECONDS: u64 = 30 * 24 * 60 * 60;
 
@@ -140,7 +141,7 @@ fn changed_fields(previous: &TaggedItem, successor: &TaggedItem) -> Vec<String> 
 
 pub fn history_summaries(payload: &VaultPayload) -> Vec<HistorySummary> {
     let cutoff = unix_timestamp().saturating_sub(HISTORY_RETENTION_SECONDS);
-    let live: Vec<TaggedItem> = payload.item_views();
+    let mut live: Vec<TaggedItem> = payload.item_views();
     let mut entries: Vec<&HistoryEntry> = payload
         .history
         .iter()
@@ -172,6 +173,7 @@ pub fn history_summaries(payload: &VaultPayload) -> Vec<HistorySummary> {
                 .unwrap_or_default(),
         });
     }
+    live.zeroize();
     summaries
 }
 
@@ -281,6 +283,9 @@ mod change_tests {
             security_code: "456".to_string(),
             ..Card::default()
         });
-        assert_eq!(changed_fields(&before, &after), vec!["security code".to_string()]);
+        assert_eq!(
+            changed_fields(&before, &after),
+            vec!["security code".to_string()]
+        );
     }
 }

--- a/src-tauri/sesame-core/src/lib.rs
+++ b/src-tauri/sesame-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod migration;
 pub mod password_analysis;
 pub mod pending_import;
 pub mod platform;
+pub mod record_store;
 pub mod snapshot;
 pub mod storage;
 pub mod throttle;
@@ -37,6 +38,8 @@ pub use pending_import::*;
 #[allow(unused_imports)]
 pub use platform::*;
 #[allow(unused_imports)]
+pub use record_store::*;
+#[allow(unused_imports)]
 pub use snapshot::*;
 #[allow(unused_imports)]
 pub use storage::*;
@@ -55,7 +58,7 @@ use std::sync::{
     Mutex,
 };
 
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroizing;
 
 pub const CORE_API_VERSION: u32 = 1;
 
@@ -219,11 +222,43 @@ pub struct UnlockedVault {
     pub pin_wrap: Option<PinWrap>,
     pub hello_wrap: Option<HelloWrap>,
     pub setup_complete: bool,
-    pub payload: VaultPayload,
+    records: record_store::VaultRecordStore,
 }
 
-impl Drop for UnlockedVault {
-    fn drop(&mut self) {
-        self.payload.zeroize();
+impl UnlockedVault {
+    pub fn from_opened(path: PathBuf, opened: &api::OpenedVault) -> VaultResult<Self> {
+        Ok(Self {
+            path,
+            key: opened.key.clone(),
+            kdf: opened.file.kdf.clone(),
+            key_wrap: opened.file.key_wrap.clone(),
+            legacy_device_wrap: opened.file.legacy_device_wrap.clone(),
+            recovery_kdf: opened.file.recovery_kdf.clone(),
+            recovery_wrap: opened.file.recovery_wrap.clone(),
+            pin_wrap: opened.file.pin_wrap.clone(),
+            hello_wrap: opened.file.hello_wrap.clone(),
+            setup_complete: opened.file.setup_complete,
+            records: record_store::VaultRecordStore::from_payload(&opened.payload)?,
+        })
+    }
+
+    pub fn open_payload(&self) -> VaultResult<record_store::OpenedPayload> {
+        self.records.open_payload()
+    }
+
+    pub fn open_item(&self, id: &str) -> VaultResult<record_store::OpenedItem> {
+        self.records.open_item(id)
+    }
+
+    pub fn snapshot(&self) -> VaultSnapshot {
+        self.records.snapshot()
+    }
+
+    pub fn trash_item_preview(&self, id: &str) -> VaultResult<ItemPreview> {
+        self.records.trash_item_preview(id)
+    }
+
+    pub fn history_item_preview(&self, id: &str) -> VaultResult<ItemPreview> {
+        self.records.history_item_preview(id)
     }
 }

--- a/src-tauri/sesame-core/src/record_store.rs
+++ b/src-tauri/sesame-core/src/record_store.rs
@@ -1,0 +1,571 @@
+use std::collections::HashSet;
+use std::ops::{Deref, DerefMut};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::crypto::{decrypt_bytes, encrypt_bytes};
+use crate::history::HISTORY_RETENTION_SECONDS;
+use crate::snapshot::snapshot_for;
+use crate::trash::TRASH_RETENTION_SECONDS;
+use crate::types::{
+    CipherBlob, Folder, HistoryEntry, ItemPreview, TaggedItem, TrashedItem, VaultPayload,
+    VaultSnapshot,
+};
+use crate::util::{fill_random, unix_timestamp};
+use crate::VaultResult;
+
+const RECORD_AAD_PREFIX: &[u8] = b"sesame:memory-record:v1";
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct VaultHeader {
+    vault_name: String,
+    folders: Vec<Folder>,
+    vault_id: Option<String>,
+    revision: u64,
+}
+
+impl Zeroize for VaultHeader {
+    fn zeroize(&mut self) {
+        self.vault_name.zeroize();
+        self.folders.zeroize();
+        self.vault_id.zeroize();
+        self.revision.zeroize();
+    }
+}
+
+struct SealedRecord {
+    id: String,
+    kind: String,
+    blob: CipherBlob,
+}
+
+pub struct VaultRecordStore {
+    key: Zeroizing<[u8; 32]>,
+    header: CipherBlob,
+    index: VaultSnapshot,
+    active: Vec<SealedRecord>,
+    trash: Vec<SealedRecord>,
+    history: Vec<SealedRecord>,
+}
+
+pub struct OpenedPayload(VaultPayload);
+
+impl Deref for OpenedPayload {
+    type Target = VaultPayload;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpenedPayload {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for OpenedPayload {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+pub struct OpenedItem(TaggedItem);
+
+impl Deref for OpenedItem {
+    type Target = TaggedItem;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for OpenedItem {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl VaultRecordStore {
+    pub(crate) fn from_payload(payload: &VaultPayload) -> VaultResult<Self> {
+        let mut key = Zeroizing::new([0_u8; 32]);
+        fill_random(&mut *key);
+        Self::from_payload_with_key(key, payload)
+    }
+
+    fn from_payload_with_key(
+        key: Zeroizing<[u8; 32]>,
+        payload: &VaultPayload,
+    ) -> VaultResult<Self> {
+        ensure_unique_active_ids(payload)?;
+        let header_value = Zeroizing::new(VaultHeader {
+            vault_name: payload.vault_name.clone(),
+            folders: payload.folders.clone(),
+            vault_id: payload.vault_id.clone(),
+            revision: payload.revision,
+        });
+        let header = seal(&key, "header", "vault", "metadata", &*header_value)?;
+        let mut active = Vec::new();
+        macro_rules! seal_active {
+            ($items:expr, $kind:expr) => {
+                for item in $items {
+                    active.push(seal_item(&key, "active", &item.id, $kind, item)?);
+                }
+            };
+        }
+        seal_active!(&payload.entries, "login");
+        seal_active!(&payload.identities, "identity");
+        seal_active!(&payload.secure_notes, "secure_note");
+        seal_active!(&payload.cards, "card");
+        seal_active!(&payload.wifi_networks, "wifi_network");
+        seal_active!(&payload.ssh_keys, "ssh_key");
+        seal_active!(&payload.software_licenses, "software_license");
+        seal_active!(&payload.documents, "document");
+        seal_active!(&payload.custom_records, "custom_record");
+        let trash = payload
+            .trash
+            .iter()
+            .map(|entry| seal_item(&key, "trash", entry.item.id(), entry.item.kind(), entry))
+            .collect::<VaultResult<Vec<_>>>()?;
+        let history = payload
+            .history
+            .iter()
+            .map(|entry| seal_item(&key, "history", &entry.id, entry.item.kind(), entry))
+            .collect::<VaultResult<Vec<_>>>()?;
+        let index = snapshot_for(payload);
+        Ok(Self {
+            key,
+            header,
+            index,
+            active,
+            trash,
+            history,
+        })
+    }
+
+    pub fn open_payload(&self) -> VaultResult<OpenedPayload> {
+        self.open_payload_with_key(&self.key)
+    }
+
+    pub fn snapshot(&self) -> VaultSnapshot {
+        self.index.clone()
+    }
+
+    fn open_payload_with_key(&self, key: &[u8; 32]) -> VaultResult<OpenedPayload> {
+        let header = Zeroizing::new(open::<VaultHeader>(
+            key,
+            "header",
+            "vault",
+            "metadata",
+            &self.header,
+        )?);
+        let mut payload = OpenedPayload(VaultPayload {
+            vault_name: header.vault_name.clone(),
+            folders: header.folders.clone(),
+            vault_id: header.vault_id.clone(),
+            revision: header.revision,
+            ..VaultPayload::default()
+        });
+        let mut active_ids = HashSet::new();
+        for record in &self.active {
+            if !active_ids.insert(record.id.as_str()) {
+                return Err(invalid_store());
+            }
+            let mut item = open_active_record(key, record)?;
+            if validate_item_locator(&item, record).is_err() {
+                item.zeroize();
+                return Err(invalid_store());
+            }
+            push_active(&mut payload, item);
+        }
+        for record in &self.trash {
+            let mut entry: TrashedItem = open_record(key, "trash", record)?;
+            if validate_item_locator(&entry.item, record).is_err() {
+                entry.zeroize();
+                return Err(invalid_store());
+            }
+            payload.trash.push(entry);
+        }
+        for record in &self.history {
+            let mut entry: HistoryEntry = open_record(key, "history", record)?;
+            if entry.id != record.id || entry.item.kind() != record.kind {
+                entry.zeroize();
+                return Err(invalid_store());
+            }
+            payload.history.push(entry);
+        }
+        Ok(payload)
+    }
+
+    pub fn open_item(&self, id: &str) -> VaultResult<OpenedItem> {
+        let record = self
+            .active
+            .iter()
+            .find(|record| record.id == id)
+            .ok_or("That saved item no longer exists.")?;
+        let mut item = open_active_record(&self.key, record)?;
+        if validate_item_locator(&item, record).is_err() {
+            item.zeroize();
+            return Err(invalid_store());
+        }
+        Ok(OpenedItem(item))
+    }
+
+    pub fn trash_item_preview(&self, id: &str) -> VaultResult<ItemPreview> {
+        let record = self
+            .trash
+            .iter()
+            .find(|record| record.id == id)
+            .ok_or("That deleted item is no longer in trash.")?;
+        let entry = Zeroizing::new(open_record::<TrashedItem>(&self.key, "trash", record)?);
+        validate_item_locator(&entry.item, record)?;
+        let cutoff = unix_timestamp().saturating_sub(TRASH_RETENTION_SECONDS);
+        if entry.deleted_at <= cutoff {
+            return Err("That deleted item is no longer in trash.".into());
+        }
+        Ok(entry.item.preview())
+    }
+
+    pub fn history_item_preview(&self, id: &str) -> VaultResult<ItemPreview> {
+        let record = self
+            .history
+            .iter()
+            .find(|record| record.id == id)
+            .ok_or("That version is no longer available.")?;
+        let entry = Zeroizing::new(open_record::<HistoryEntry>(&self.key, "history", record)?);
+        if entry.id != record.id || entry.item.kind() != record.kind {
+            return Err(invalid_store());
+        }
+        let cutoff = unix_timestamp().saturating_sub(HISTORY_RETENTION_SECONDS);
+        if entry.captured_at <= cutoff {
+            return Err("That version is no longer available.".into());
+        }
+        Ok(entry.item.preview())
+    }
+
+    #[cfg(test)]
+    fn replace_payload(&mut self, payload: &VaultPayload) -> VaultResult<()> {
+        let mut replacement_key = Zeroizing::new([0_u8; 32]);
+        fill_random(&mut *replacement_key);
+        let replacement = Self::from_payload_with_key(replacement_key, payload)?;
+        *self = replacement;
+        Ok(())
+    }
+}
+
+fn ensure_unique_active_ids(payload: &VaultPayload) -> VaultResult<()> {
+    let mut ids = HashSet::new();
+    macro_rules! check_ids {
+        ($items:expr) => {
+            for item in $items {
+                if !ids.insert(item.id.as_str()) {
+                    return Err(
+                        "The vault contains duplicate item ids and cannot be saved safely.".into(),
+                    );
+                }
+            }
+        };
+    }
+    check_ids!(&payload.entries);
+    check_ids!(&payload.identities);
+    check_ids!(&payload.secure_notes);
+    check_ids!(&payload.cards);
+    check_ids!(&payload.wifi_networks);
+    check_ids!(&payload.ssh_keys);
+    check_ids!(&payload.software_licenses);
+    check_ids!(&payload.documents);
+    check_ids!(&payload.custom_records);
+    Ok(())
+}
+
+fn seal_item<T: Serialize>(
+    key: &[u8; 32],
+    role: &str,
+    id: &str,
+    kind: &str,
+    value: &T,
+) -> VaultResult<SealedRecord> {
+    Ok(SealedRecord {
+        id: id.to_string(),
+        kind: kind.to_string(),
+        blob: seal(key, role, id, kind, value)?,
+    })
+}
+
+fn seal<T: Serialize>(
+    key: &[u8; 32],
+    role: &str,
+    id: &str,
+    kind: &str,
+    value: &T,
+) -> VaultResult<CipherBlob> {
+    let plaintext = Zeroizing::new(
+        serde_json::to_vec(value)
+            .map_err(|_| "Sesame could not protect the unlocked vault session.".to_string())?,
+    );
+    encrypt_bytes(key, &plaintext, &record_aad(role, id, kind))
+        .map_err(|_| "Sesame could not protect the unlocked vault session.".to_string())
+}
+
+fn open_record<T: DeserializeOwned>(
+    key: &[u8; 32],
+    role: &str,
+    record: &SealedRecord,
+) -> VaultResult<T> {
+    open(key, role, &record.id, &record.kind, &record.blob)
+}
+
+fn open_active_record(key: &[u8; 32], record: &SealedRecord) -> VaultResult<TaggedItem> {
+    let item = match record.kind.as_str() {
+        "login" => TaggedItem::Login(open_record(key, "active", record)?),
+        "identity" => TaggedItem::Identity(open_record(key, "active", record)?),
+        "secure_note" => TaggedItem::SecureNote(open_record(key, "active", record)?),
+        "card" => TaggedItem::Card(open_record(key, "active", record)?),
+        "wifi_network" => TaggedItem::WifiNetwork(open_record(key, "active", record)?),
+        "ssh_key" => TaggedItem::SshKey(open_record(key, "active", record)?),
+        "software_license" => TaggedItem::SoftwareLicense(open_record(key, "active", record)?),
+        "document" => TaggedItem::Document(open_record(key, "active", record)?),
+        "custom_record" => TaggedItem::CustomRecord(open_record(key, "active", record)?),
+        _ => return Err(invalid_store()),
+    };
+    Ok(item)
+}
+
+fn push_active(payload: &mut VaultPayload, item: TaggedItem) {
+    match item {
+        TaggedItem::Login(item) => payload.entries.push(item),
+        TaggedItem::Identity(item) => payload.identities.push(item),
+        TaggedItem::SecureNote(item) => payload.secure_notes.push(item),
+        TaggedItem::Card(item) => payload.cards.push(item),
+        TaggedItem::WifiNetwork(item) => payload.wifi_networks.push(item),
+        TaggedItem::SshKey(item) => payload.ssh_keys.push(item),
+        TaggedItem::SoftwareLicense(item) => payload.software_licenses.push(item),
+        TaggedItem::Document(item) => payload.documents.push(item),
+        TaggedItem::CustomRecord(item) => payload.custom_records.push(item),
+    }
+}
+
+fn open<T: DeserializeOwned>(
+    key: &[u8; 32],
+    role: &str,
+    id: &str,
+    kind: &str,
+    blob: &CipherBlob,
+) -> VaultResult<T> {
+    let plaintext = Zeroizing::new(
+        decrypt_bytes(key, blob, &record_aad(role, id, kind)).map_err(|_| invalid_store())?,
+    );
+    serde_json::from_slice(&plaintext).map_err(|_| invalid_store())
+}
+
+fn validate_item_locator(item: &TaggedItem, record: &SealedRecord) -> VaultResult<()> {
+    if item.id() != record.id || item.kind() != record.kind {
+        return Err(invalid_store());
+    }
+    Ok(())
+}
+
+fn record_aad(role: &str, id: &str, kind: &str) -> Vec<u8> {
+    let mut aad =
+        Vec::with_capacity(RECORD_AAD_PREFIX.len() + role.len() + id.len() + kind.len() + 12);
+    aad.extend_from_slice(RECORD_AAD_PREFIX);
+    for value in [role.as_bytes(), id.as_bytes(), kind.as_bytes()] {
+        aad.extend_from_slice(&(value.len() as u32).to_be_bytes());
+        aad.extend_from_slice(value);
+    }
+    aad
+}
+
+fn invalid_store() -> String {
+    "The unlocked vault session could not be authenticated. Lock and unlock Sesame again."
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::VaultEntry;
+
+    fn payload() -> VaultPayload {
+        VaultPayload {
+            vault_name: "Fictional vault".to_string(),
+            entries: vec![
+                VaultEntry {
+                    id: "login-a".to_string(),
+                    title: "Northwind".to_string(),
+                    password: "fictional-alpha-secret".to_string(),
+                    ..VaultEntry::default()
+                },
+                VaultEntry {
+                    id: "login-b".to_string(),
+                    title: "Contoso".to_string(),
+                    password: "fictional-beta-secret".to_string(),
+                    ..VaultEntry::default()
+                },
+            ],
+            vault_id: Some("vault-fictional".to_string()),
+            revision: 7,
+            ..VaultPayload::default()
+        }
+    }
+
+    #[test]
+    fn round_trip_keeps_records_and_metadata() {
+        let store = VaultRecordStore::from_payload(&payload()).expect("record store");
+
+        let opened = store.open_payload().expect("opened payload");
+
+        assert_eq!(opened.vault_name, "Fictional vault");
+        assert_eq!(opened.vault_id.as_deref(), Some("vault-fictional"));
+        assert_eq!(opened.revision, 7);
+        assert_eq!(opened.entries.len(), 2);
+        assert_eq!(opened.entries[1].password, "fictional-beta-secret");
+    }
+
+    #[test]
+    fn one_item_can_open_without_opening_the_other_records() {
+        let store = VaultRecordStore::from_payload(&payload()).expect("record store");
+
+        let opened = store.open_item("login-b").expect("opened item");
+
+        let password = match &*opened {
+            TaggedItem::Login(entry) => entry.password.as_str(),
+            _ => "",
+        };
+        assert_eq!(password, "fictional-beta-secret");
+    }
+
+    #[test]
+    fn wrong_key_cannot_open_records() {
+        let store = VaultRecordStore::from_payload_with_key(Zeroizing::new([9_u8; 32]), &payload())
+            .expect("record store");
+
+        let result = store.open_payload_with_key(&[10_u8; 32]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn swapped_record_ciphertexts_are_rejected() {
+        let mut store = VaultRecordStore::from_payload(&payload()).expect("record store");
+        let (left, right) = store.active.split_at_mut(1);
+        std::mem::swap(&mut left[0].blob, &mut right[0].blob);
+
+        let result = store.open_payload();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn relabelled_records_are_rejected() {
+        let mut store = VaultRecordStore::from_payload(&payload()).expect("record store");
+        let original_kind = store.active[0].kind.clone();
+        store.active[0].kind = "card".to_string();
+
+        assert!(store.open_payload().is_err());
+        assert!(store.open_item("login-a").is_err());
+
+        store.active[0].kind = original_kind;
+        store.active[0].id = "login-b".to_string();
+
+        assert!(store.open_payload().is_err());
+        assert!(store.open_item("login-b").is_err());
+    }
+
+    #[test]
+    fn opened_plaintext_zeroizes_in_place() {
+        let store = VaultRecordStore::from_payload(&payload()).expect("record store");
+        let mut opened = store.open_payload().expect("opened payload");
+
+        opened.zeroize();
+
+        assert!(opened.entries.is_empty());
+        assert!(opened.history.is_empty());
+        assert!(opened.vault_name.is_empty());
+
+        let mut item = TaggedItem::Login(VaultEntry {
+            id: "login-a".to_string(),
+            password: "fictional-alpha-secret".to_string(),
+            ..VaultEntry::default()
+        });
+        item.zeroize();
+
+        assert!(matches!(&item, TaggedItem::Login(entry) if entry.password.is_empty()));
+    }
+
+    #[test]
+    fn malformed_record_is_rejected() {
+        let mut store = VaultRecordStore::from_payload(&payload()).expect("record store");
+        store.active[0].blob.ciphertext = "not-base64".to_string();
+
+        let result = store.open_payload();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn failed_replacement_keeps_the_previous_records() {
+        let mut store = VaultRecordStore::from_payload(&payload()).expect("record store");
+        let mut invalid = payload();
+        invalid.entries[1].id = invalid.entries[0].id.clone();
+
+        let result = store.replace_payload(&invalid);
+
+        assert!(result.is_err());
+        let opened = store.open_payload().expect("previous payload");
+        assert_eq!(opened.entries[0].id, "login-a");
+        assert_eq!(opened.entries[1].id, "login-b");
+    }
+
+    #[test]
+    fn idle_index_omits_secret_canaries() {
+        let store = VaultRecordStore::from_payload(&payload()).expect("record store");
+
+        let index = serde_json::to_string(&store.snapshot()).expect("serialized index");
+
+        assert!(!index.contains("fictional-alpha-secret"));
+        assert!(!index.contains("fictional-beta-secret"));
+        assert!(index.contains("Northwind"));
+        assert!(index.contains("Contoso"));
+    }
+
+    #[test]
+    fn idle_index_does_not_open_tampered_records() {
+        let mut store = VaultRecordStore::from_payload(&payload()).expect("record store");
+        store.active[0].blob.ciphertext = "not-base64".to_string();
+
+        let index = store.snapshot();
+
+        assert_eq!(index.entries.len(), 2);
+        assert!(store.open_item("login-a").is_err());
+    }
+
+    #[test]
+    fn selected_trash_and_history_previews_do_not_return_secrets() {
+        let mut value = payload();
+        value.trash.push(TrashedItem {
+            item: TaggedItem::Login(value.entries[0].clone()),
+            deleted_at: unix_timestamp(),
+        });
+        value.history.push(HistoryEntry {
+            id: "fictional-history".to_string(),
+            item: TaggedItem::Login(value.entries[1].clone()),
+            captured_at: unix_timestamp(),
+            operation: Default::default(),
+        });
+        let store = VaultRecordStore::from_payload(&value).expect("record store");
+
+        let trash = store.trash_item_preview("login-a").expect("trash preview");
+        let history = store
+            .history_item_preview("fictional-history")
+            .expect("history preview");
+        let previews = serde_json::to_string(&(trash, history)).expect("serialized previews");
+
+        assert!(previews.contains("Northwind"));
+        assert!(previews.contains("Contoso"));
+        assert!(!previews.contains("fictional-alpha-secret"));
+        assert!(!previews.contains("fictional-beta-secret"));
+    }
+}

--- a/src-tauri/sesame-core/src/snapshot.rs
+++ b/src-tauri/sesame-core/src/snapshot.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use totp_rs::{Algorithm as TotpAlgorithm, Secret, TOTP};
+use zeroize::Zeroize;
 
 use crate::{
     password_analysis::analyse_password,
@@ -14,7 +15,8 @@ pub fn snapshot_for(payload: &VaultPayload) -> VaultSnapshot {
     let password_counts = password_counts(payload);
     let mut entries = Vec::new();
     let mut items = Vec::new();
-    for item in payload.item_views() {
+    let mut active_items = payload.item_views();
+    for item in &active_items {
         if let TaggedItem::Login(entry) = &item {
             let reused = !entry.password.is_empty()
                 && password_counts.get(&entry.password).copied().unwrap_or(0) > 1;
@@ -42,8 +44,9 @@ pub fn snapshot_for(payload: &VaultPayload) -> VaultSnapshot {
             });
             continue;
         }
-        items.push(item_summary_for(payload, &item));
+        items.push(item_summary_for(payload, item));
     }
+    active_items.zeroize();
     entries.sort_by(|left, right| left.title.to_lowercase().cmp(&right.title.to_lowercase()));
     items.sort_by(|left, right| left.title.to_lowercase().cmp(&right.title.to_lowercase()));
     let mut trash = crate::trash::trash_summaries(payload);
@@ -165,7 +168,7 @@ pub fn security_summary(payload: &VaultPayload) -> SecuritySummary {
     }
 }
 
-pub fn login_card_for(payload: &VaultPayload, entry: &VaultEntry) -> LoginCard {
+pub fn login_card_for(folders: &[Folder], entry: &VaultEntry) -> LoginCard {
     let (totp_code, totp_remaining) = entry
         .totp
         .as_deref()
@@ -186,7 +189,7 @@ pub fn login_card_for(payload: &VaultPayload, entry: &VaultEntry) -> LoginCard {
         email: entry.email.clone(),
         password: entry.password.clone(),
         folder_id: entry.folder_id.clone(),
-        folder: folder_name_for(payload, entry),
+        folder: folder_name_from(folders, entry.folder_id.as_deref(), &entry.folder),
         favourite: entry.favourite,
         last_used_at: entry.last_used_at,
         has_totp: entry.totp.as_deref().is_some_and(|seed| !seed.is_empty()),
@@ -280,13 +283,26 @@ pub fn login_summary_for(entry: &VaultEntry) -> LoginSummary {
 }
 
 pub fn duplicate_groups_for(payload: &VaultPayload) -> Vec<DuplicateGroup> {
-    let mut groups = entries_by_duplicate_key(&payload.entries)
+    duplicate_groups_from_summaries(payload.entries.iter().map(login_summary_for).collect())
+}
+
+pub fn duplicate_groups_from_summaries(summaries: Vec<LoginSummary>) -> Vec<DuplicateGroup> {
+    let mut by_key = HashMap::new();
+    for summary in summaries {
+        if summary.duplicate_key != ":" {
+            by_key
+                .entry(summary.duplicate_key.clone())
+                .or_insert_with(Vec::new)
+                .push(summary);
+        }
+    }
+    let mut groups = by_key
         .into_iter()
         .filter_map(|(id, entries)| {
             if entries.len() < 2 {
                 return None;
             }
-            let site = domain_from_url(&entries[0].url);
+            let site = entries[0].site.clone();
             let label = if site.is_empty() {
                 entries[0].title.clone()
             } else {
@@ -299,11 +315,11 @@ pub fn duplicate_groups_for(payload: &VaultPayload) -> Vec<DuplicateGroup> {
                 entries: entries
                     .into_iter()
                     .map(|entry| CleanupEntry {
-                        id: entry.id.clone(),
-                        title: entry.title.clone(),
-                        site: domain_from_url(&entry.url),
-                        username: entry.username.clone(),
-                        initials: initials_for(&entry.title),
+                        id: entry.id,
+                        title: entry.title,
+                        site: entry.site,
+                        username: entry.username,
+                        initials: entry.initials,
                         reason: "Same website and username",
                     })
                     .collect(),
@@ -482,19 +498,22 @@ pub fn issue_kinds_for(
 }
 
 pub fn folder_name(payload: &VaultPayload, folder_id: Option<&str>) -> String {
-    folder_id
-        .and_then(|folder_id| payload.folders.iter().find(|folder| folder.id == folder_id))
+    folder_name_from(&payload.folders, folder_id, "")
+}
+
+fn folder_name_from(folders: &[Folder], folder_id: Option<&str>, fallback: &str) -> String {
+    let name = folder_id
+        .and_then(|folder_id| folders.iter().find(|folder| folder.id == folder_id))
         .map(|folder| folder.name.clone())
-        .unwrap_or_default()
+        .unwrap_or_default();
+    if name.is_empty() {
+        return fallback.to_string();
+    }
+    name
 }
 
 pub fn folder_name_for(payload: &VaultPayload, entry: &VaultEntry) -> String {
-    let name = folder_name(payload, entry.folder_id.as_deref());
-    if name.is_empty() {
-        // Only transient imports and pre-migration payloads have this value.
-        return entry.folder.clone();
-    }
-    name
+    folder_name_from(&payload.folders, entry.folder_id.as_deref(), &entry.folder)
 }
 
 pub fn duplicate_key(entry: &VaultEntry) -> String {

--- a/src-tauri/sesame-core/src/storage.rs
+++ b/src-tauri/sesame-core/src/storage.rs
@@ -16,6 +16,7 @@ use crate::platform::{
 use crate::snapshot::duplicate_key;
 use crate::{
     payload_aad_for_file,
+    record_store::VaultRecordStore,
     throttle::{PersistedPinThrottle, PinAttemptGuard},
     UnlockedVault, VaultResult, PIN_WRAP_AAD, RECOVERY_WRAP_AAD, VAULT_FORMAT_VERSION, WRAP_AAD,
 };
@@ -119,64 +120,69 @@ pub fn persist_session(session: &mut UnlockedVault) -> VaultResult<()> {
     if !session.setup_complete {
         return Err("Verify your recovery kit before using this vault.".into());
     }
-    session.payload.revision += 1;
-    let result = persist_session_internal(session, true);
-    if result.is_err() {
-        session.payload.revision -= 1;
-    }
-    result
+    let payload = session.open_payload()?;
+    persist_payload(session, payload.clone(), true)
 }
 
 pub fn persist_session_without_previous(session: &mut UnlockedVault) -> VaultResult<()> {
     if !session.setup_complete {
         return Err("Verify your recovery kit before using this vault.".into());
     }
-    session.payload.revision += 1;
-    let result = persist_session_internal(session, false);
-    if result.is_err() {
-        session.payload.revision -= 1;
-    }
+    let payload = session.open_payload()?;
+    persist_payload(session, payload.clone(), false)
+}
+
+fn persist_payload(
+    session: &mut UnlockedVault,
+    mut next_payload: VaultPayload,
+    keep_previous: bool,
+) -> VaultResult<()> {
+    let result = (|| {
+        next_payload.revision += 1;
+        let next_records = VaultRecordStore::from_payload(&next_payload)?;
+        let payload_aad = payload_aad_for_file(VAULT_FORMAT_VERSION, session.setup_complete)?;
+        let file = VaultFile {
+            format_version: VAULT_FORMAT_VERSION,
+            kdf: session.kdf.clone(),
+            key_wrap: session.key_wrap.clone(),
+            legacy_device_wrap: session.legacy_device_wrap.clone(),
+            recovery_kdf: session.recovery_kdf.clone(),
+            recovery_wrap: session.recovery_wrap.clone(),
+            pin_wrap: session.pin_wrap.clone(),
+            hello_wrap: session.hello_wrap.clone(),
+            setup_complete: session.setup_complete,
+            payload: encrypt_bytes(
+                &session.key,
+                &serialize_payload(&next_payload)?,
+                payload_aad,
+            )?,
+        };
+        if keep_previous {
+            write_vault_file(&session.path, &file)?;
+        } else {
+            write_vault_file_without_previous(&session.path, &file)?;
+        }
+        session.records = next_records;
+        Ok(())
+    })();
+    next_payload.zeroize();
     result
 }
 
-fn persist_session_internal(session: &UnlockedVault, keep_previous: bool) -> VaultResult<()> {
-    let payload_aad = payload_aad_for_file(VAULT_FORMAT_VERSION, session.setup_complete)?;
-    let file = VaultFile {
-        format_version: VAULT_FORMAT_VERSION,
-        kdf: session.kdf.clone(),
-        key_wrap: session.key_wrap.clone(),
-        legacy_device_wrap: session.legacy_device_wrap.clone(),
-        recovery_kdf: session.recovery_kdf.clone(),
-        recovery_wrap: session.recovery_wrap.clone(),
-        pin_wrap: session.pin_wrap.clone(),
-        hello_wrap: session.hello_wrap.clone(),
-        setup_complete: session.setup_complete,
-        payload: encrypt_bytes(
-            &session.key,
-            &serialize_payload(&session.payload)?,
-            payload_aad,
-        )?,
-    };
-    if keep_previous {
-        write_vault_file(&session.path, &file)
-    } else {
-        write_vault_file_without_previous(&session.path, &file)
-    }
-}
-
-fn pending_setup_is_empty(session: &UnlockedVault) -> bool {
-    session.payload.folders.is_empty()
-        && session.payload.entries.is_empty()
-        && session.payload.identities.is_empty()
-        && session.payload.secure_notes.is_empty()
-        && session.payload.cards.is_empty()
-        && session.payload.wifi_networks.is_empty()
-        && session.payload.ssh_keys.is_empty()
-        && session.payload.software_licenses.is_empty()
-        && session.payload.documents.is_empty()
-        && session.payload.custom_records.is_empty()
-        && session.payload.trash.is_empty()
-        && session.payload.history.is_empty()
+fn pending_setup_is_empty(session: &UnlockedVault) -> VaultResult<bool> {
+    let payload = session.open_payload()?;
+    Ok(payload.folders.is_empty()
+        && payload.entries.is_empty()
+        && payload.identities.is_empty()
+        && payload.secure_notes.is_empty()
+        && payload.cards.is_empty()
+        && payload.wifi_networks.is_empty()
+        && payload.ssh_keys.is_empty()
+        && payload.software_licenses.is_empty()
+        && payload.documents.is_empty()
+        && payload.custom_records.is_empty()
+        && payload.trash.is_empty()
+        && payload.history.is_empty())
 }
 
 /// Replaces the abandoned kit; only the new one can finish or recover the pending vault.
@@ -184,7 +190,7 @@ pub fn resume_recovery_setup_for_session(session: &mut UnlockedVault) -> VaultRe
     if session.setup_complete {
         return Err("This vault has already finished recovery setup.".into());
     }
-    if !pending_setup_is_empty(session) {
+    if !pending_setup_is_empty(session)? {
         return Err("This unfinished vault contains data and cannot restart setup safely.".into());
     }
 
@@ -200,9 +206,8 @@ pub fn resume_recovery_setup_for_session(session: &mut UnlockedVault) -> VaultRe
 
     let previous_kdf = session.recovery_kdf.replace(recovery_kdf);
     let previous_wrap = session.recovery_wrap.replace(recovery_wrap);
-    session.payload.revision += 1;
-    if let Err(error) = persist_session_internal(session, false) {
-        session.payload.revision -= 1;
+    let payload = session.open_payload()?;
+    if let Err(error) = persist_payload(session, payload.clone(), false) {
         session.recovery_kdf = previous_kdf;
         session.recovery_wrap = previous_wrap;
         return Err(error);
@@ -403,12 +408,14 @@ pub fn commit_payload_change(
     session: &mut UnlockedVault,
     next_payload: VaultPayload,
 ) -> VaultResult<()> {
-    let previous_payload = std::mem::replace(&mut session.payload, next_payload);
-    if let Err(error) = persist_session(session) {
-        session.payload = previous_payload;
-        return Err(error);
-    }
-    Ok(())
+    persist_payload(session, next_payload, true)
+}
+
+pub fn commit_payload_change_without_previous(
+    session: &mut UnlockedVault,
+    next_payload: VaultPayload,
+) -> VaultResult<()> {
+    persist_payload(session, next_payload, false)
 }
 
 pub fn payload_without_login(payload: &VaultPayload, id: &str) -> VaultResult<VaultPayload> {
@@ -555,12 +562,13 @@ pub fn delete_folder_from_payload(
     let mut next_payload = payload.clone();
     next_payload.folders.retain(|folder| folder.id != folder_id);
     let now = unix_timestamp();
-    let filed: Vec<String> = next_payload
-        .item_views()
+    let mut items = next_payload.item_views();
+    let filed: Vec<String> = items
         .iter()
         .filter(|item| item.metadata().item_folder_id() == Some(folder_id))
         .map(|item| item.id().to_string())
         .collect();
+    items.zeroize();
     for id in filed {
         if let Some(item) = next_payload.item_metadata_mut(&id) {
             item.set_item_folder_id(None);
@@ -813,4 +821,99 @@ pub fn atomic_replace(destination: &Path, bytes: &[u8]) -> VaultResult<()> {
         return Err(error);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::api::{create_vault, open_vault_with_password, open_vault_with_recovery_kit};
+
+    fn test_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("sesame-{name}-{}", random_id()))
+    }
+
+    fn unlocked_at(path: PathBuf, password: &str) -> UnlockedVault {
+        let (opened, _) = create_vault(password, "Fictional vault").expect("created test vault");
+        let mut unlocked = UnlockedVault::from_opened(path, &opened).expect("unlocked vault");
+        unlocked.setup_complete = true;
+        unlocked
+    }
+
+    #[test]
+    fn persisted_session_stays_compatible_with_the_current_vault_format() {
+        let directory = test_path("record-format");
+        let path = directory.join("vault.sesame");
+        let password = "fictional master password";
+        let mut session = unlocked_at(path.clone(), password);
+        let mut payload = session.open_payload().expect("opened payload").clone();
+        payload.entries.push(VaultEntry {
+            id: "fictional-login".to_string(),
+            title: "Northwind".to_string(),
+            password: "fictional-secret".to_string(),
+            ..VaultEntry::default()
+        });
+
+        commit_payload_change(&mut session, payload).expect("persisted session");
+
+        let index = session.snapshot();
+        assert_eq!(index.revision, 2);
+        assert_eq!(index.entries.len(), 1);
+        assert_eq!(index.entries[0].id, "fictional-login");
+        let bytes = fs::read(&path).expect("vault bytes");
+        let file: VaultFile = serde_json::from_slice(&bytes).expect("vault file");
+        let opened = open_vault_with_password(&file, password).expect("opened vault");
+        assert_eq!(file.format_version, VAULT_FORMAT_VERSION);
+        assert_eq!(opened.payload.entries.len(), 1);
+        assert_eq!(opened.payload.entries[0].password, "fictional-secret");
+        fs::remove_dir_all(directory).expect("removed test directory");
+    }
+
+    #[test]
+    fn failed_write_keeps_the_previous_session_records() {
+        let directory = test_path("record-rollback");
+        fs::create_dir_all(&directory).expect("test directory");
+        let blocked_parent = directory.join("blocked");
+        fs::write(&blocked_parent, b"not a directory").expect("blocking file");
+        let mut session = unlocked_at(
+            blocked_parent.join("vault.sesame"),
+            "fictional master password",
+        );
+        let mut changed = session.open_payload().expect("opened payload").clone();
+        changed.vault_name = "Changed vault".to_string();
+
+        let result = commit_payload_change(&mut session, changed);
+
+        assert!(result.is_err());
+        let index = session.snapshot();
+        assert_eq!(index.vault_name, "Fictional vault");
+        assert_eq!(index.revision, 1);
+        let current = session.open_payload().expect("previous payload");
+        assert_eq!(current.vault_name, "Fictional vault");
+        assert_eq!(current.revision, 1);
+        fs::remove_dir_all(directory).expect("removed test directory");
+    }
+
+    #[test]
+    fn password_rotation_rewraps_the_same_records_for_password_and_recovery() {
+        let directory = test_path("record-rotation");
+        let path = directory.join("vault.sesame");
+        let old_password = "fictional old password";
+        let new_password = "fictional new password";
+        let mut session = unlocked_at(path.clone(), old_password);
+        persist_session(&mut session).expect("initial persisted session");
+
+        let recovery_kit =
+            rotate_master_password_for_session(&mut session, old_password, new_password)
+                .expect("rotated password");
+
+        let bytes = fs::read(&path).expect("vault bytes");
+        let file: VaultFile = serde_json::from_slice(&bytes).expect("vault file");
+        assert!(open_vault_with_password(&file, old_password).is_err());
+        assert!(open_vault_with_password(&file, new_password).is_ok());
+        assert!(open_vault_with_recovery_kit(&file, &recovery_kit).is_ok());
+        assert!(!path.with_extension("sesame.prev").exists());
+        fs::remove_dir_all(directory).expect("removed test directory");
+    }
 }

--- a/src-tauri/sesame-core/src/types.rs
+++ b/src-tauri/sesame-core/src/types.rs
@@ -117,7 +117,7 @@ pub struct VaultSetup {
     pub recovery_kit: String,
 }
 
-#[derive(Serialize, ts_rs::TS)]
+#[derive(Serialize, Clone, ts_rs::TS)]
 #[ts(export, optional_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct VaultSnapshot {
@@ -146,7 +146,7 @@ pub struct Folder {
 // full secret-bearing login record (this file's other `VaultEntry` struct,
 // never exposed to the frontend under that shape). Do not derive TS on that
 // other struct.
-#[derive(Serialize, ts_rs::TS)]
+#[derive(Serialize, Clone, ts_rs::TS)]
 #[ts(export, optional_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct VaultEntrySummary {
@@ -213,7 +213,7 @@ pub struct PasswordIssue {
     pub explanation: &'static str,
 }
 
-#[derive(Serialize, ts_rs::TS)]
+#[derive(Serialize, Clone, ts_rs::TS)]
 #[ts(export, optional_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct SecuritySummary {
@@ -1051,7 +1051,6 @@ pub struct IdentityInput {
     pub country: String,
     #[serde(default)]
     pub tags: Vec<String>,
-
 }
 
 #[derive(Serialize, ts_rs::TS)]
@@ -1107,7 +1106,6 @@ pub struct SecureNoteInput {
     pub content: String,
     #[serde(default)]
     pub tags: Vec<String>,
-
 }
 
 #[derive(Serialize, ts_rs::TS)]
@@ -1187,7 +1185,6 @@ pub struct CardInput {
     pub notes: String,
     #[serde(default)]
     pub tags: Vec<String>,
-
 }
 
 #[derive(Serialize, ts_rs::TS)]
@@ -1253,7 +1250,6 @@ pub struct WifiNetworkInput {
     pub notes: String,
     #[serde(default)]
     pub tags: Vec<String>,
-
 }
 
 #[derive(Serialize, ts_rs::TS)]
@@ -1323,7 +1319,6 @@ pub struct SshKeyInput {
     pub notes: String,
     #[serde(default)]
     pub tags: Vec<String>,
-
 }
 
 #[derive(Serialize, ts_rs::TS)]
@@ -1393,7 +1388,6 @@ pub struct SoftwareLicenseInput {
     pub notes: String,
     #[serde(default)]
     pub tags: Vec<String>,
-
 }
 
 #[derive(Serialize, ts_rs::TS)]
@@ -1498,7 +1492,6 @@ pub struct DocumentMetadataInput {
     pub notes: String,
     #[serde(default)]
     pub tags: Vec<String>,
-
 }
 
 #[derive(Serialize, ts_rs::TS)]
@@ -1566,7 +1559,6 @@ pub struct CustomRecordInput {
     pub notes: String,
     #[serde(default)]
     pub tags: Vec<String>,
-
 }
 
 #[derive(Serialize, ts_rs::TS)]
@@ -1660,6 +1652,12 @@ struct PersistedVaultPayloadV8<'a> {
     revision: u64,
 }
 
+impl Drop for PersistedVaultPayloadV8<'_> {
+    fn drop(&mut self) {
+        self.items.zeroize();
+    }
+}
+
 /// Private: an older binary is rejected before it can decrypt a v8 payload.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1748,11 +1746,37 @@ impl VaultPayload {
     }
 
     pub fn active_item(&self, id: &str) -> Option<TaggedItem> {
-        self.item_views().into_iter().find(|item| item.id() == id)
+        macro_rules! find_item {
+            ($collection:expr, $variant:ident) => {
+                if let Some(item) = $collection.iter().find(|item| item.id == id) {
+                    return Some(TaggedItem::$variant(item.clone()));
+                }
+            };
+        }
+        find_item!(self.entries, Login);
+        find_item!(self.identities, Identity);
+        find_item!(self.secure_notes, SecureNote);
+        find_item!(self.cards, Card);
+        find_item!(self.wifi_networks, WifiNetwork);
+        find_item!(self.ssh_keys, SshKey);
+        find_item!(self.software_licenses, SoftwareLicense);
+        find_item!(self.documents, Document);
+        find_item!(self.custom_records, CustomRecord);
+        None
     }
 
     pub fn insert_active_item(&mut self, item: TaggedItem) -> Result<(), String> {
-        if self.active_item(item.id()).is_some() {
+        let id = item.id();
+        if self.entries.iter().any(|item| item.id == id)
+            || self.identities.iter().any(|item| item.id == id)
+            || self.secure_notes.iter().any(|item| item.id == id)
+            || self.cards.iter().any(|item| item.id == id)
+            || self.wifi_networks.iter().any(|item| item.id == id)
+            || self.ssh_keys.iter().any(|item| item.id == id)
+            || self.software_licenses.iter().any(|item| item.id == id)
+            || self.documents.iter().any(|item| item.id == id)
+            || self.custom_records.iter().any(|item| item.id == id)
+        {
             return Err("A saved item with that id already exists.".into());
         }
         match item {
@@ -1791,13 +1815,27 @@ impl VaultPayload {
 
     fn active_items(&self) -> Result<Vec<TaggedItem>, &'static str> {
         let mut ids = std::collections::HashSet::new();
-        let items = self.item_views();
-        for item in &items {
-            if !ids.insert(item.id().to_string()) {
-                return Err("The vault contains duplicate item ids and cannot be migrated safely.");
-            }
+        macro_rules! check_ids {
+            ($items:expr) => {
+                for item in $items {
+                    if !ids.insert(item.id.as_str()) {
+                        return Err(
+                            "The vault contains duplicate item ids and cannot be migrated safely.",
+                        );
+                    }
+                }
+            };
         }
-        Ok(items)
+        check_ids!(&self.entries);
+        check_ids!(&self.identities);
+        check_ids!(&self.secure_notes);
+        check_ids!(&self.cards);
+        check_ids!(&self.wifi_networks);
+        check_ids!(&self.ssh_keys);
+        check_ids!(&self.software_licenses);
+        check_ids!(&self.documents);
+        check_ids!(&self.custom_records);
+        Ok(self.item_views())
     }
 
     fn from_stored(stored: StoredVaultPayload) -> Result<Self, &'static str> {
@@ -2194,6 +2232,8 @@ impl Zeroize for VaultPayload {
         self.custom_records.zeroize();
         self.trash.zeroize();
         self.history.zeroize();
+        self.vault_id.zeroize();
+        self.revision.zeroize();
     }
 }
 
@@ -2436,7 +2476,8 @@ mod tests {
     #[test]
     fn records_stored_without_the_array_keys_still_load() {
         let note: SecureNote =
-            serde_json::from_str(r#"{"id":"a","title":"Wi-Fi","content":"example note body"}"#).unwrap();
+            serde_json::from_str(r#"{"id":"a","title":"Wi-Fi","content":"example note body"}"#)
+                .unwrap();
         assert!(note.tags.is_empty());
         let document: DocumentMetadata =
             serde_json::from_str(r#"{"id":"b","title":"Passport"}"#).unwrap();

--- a/src-tauri/sesame-core/tests/totp.rs
+++ b/src-tauri/sesame-core/tests/totp.rs
@@ -1,6 +1,6 @@
 use sesame_core::imports::resolved_totp;
 use sesame_core::snapshot::{login_card_for, totp_from_value};
-use sesame_core::types::{VaultEntry, VaultPayload};
+use sesame_core::types::VaultEntry;
 
 // RFC 6238 test key "12345678901234567890" in base32.
 const RFC_KEY: &str = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
@@ -25,7 +25,11 @@ fn a_secret_is_read_however_the_site_printed_it() {
         let Some(totp) = parsed else {
             panic!("{name} secret was rejected");
         };
-        assert_eq!(totp.generate(59), "287082", "{name} produced a different code");
+        assert_eq!(
+            totp.generate(59),
+            "287082",
+            "{name} produced a different code"
+        );
     }
 }
 
@@ -65,7 +69,7 @@ fn the_login_card_derives_a_code_but_never_carries_the_seed() {
         totp: Some(RFC_KEY.to_string()),
         ..VaultEntry::default()
     };
-    let card = login_card_for(&VaultPayload::default(), &entry);
+    let card = login_card_for(&[], &entry);
     let wire = serde_json::to_string(&card).expect("the card serializes");
     assert!(card.has_totp, "a configured seed was not reported");
     assert!(card.totp_code.is_some(), "no code was derived");
@@ -78,7 +82,7 @@ fn the_login_card_derives_a_code_but_never_carries_the_seed() {
         title: "Example".into(),
         ..VaultEntry::default()
     };
-    assert!(!login_card_for(&VaultPayload::default(), &bare).has_totp);
+    assert!(!login_card_for(&[], &bare).has_totp);
 }
 
 #[test]
@@ -91,7 +95,10 @@ fn a_save_that_omits_the_secret_keeps_the_stored_one() {
 
 #[test]
 fn an_explicitly_emptied_secret_is_cleared() {
-    assert_eq!(resolved_totp(Some(String::new()), Some(RFC_KEY.to_string())), None);
+    assert_eq!(
+        resolved_totp(Some(String::new()), Some(RFC_KEY.to_string())),
+        None
+    );
 }
 
 #[test]

--- a/src-tauri/src/adapters/platform/autotype.rs
+++ b/src-tauri/src/adapters/platform/autotype.rs
@@ -4,19 +4,7 @@
 use tauri::State;
 use zeroize::Zeroize;
 
-use crate::vault::{VaultPayload, VaultResult, VaultState};
-
-fn credentials_for(payload: &VaultPayload, id: &str) -> VaultResult<(String, String)> {
-    let entry = payload
-        .entries
-        .iter()
-        .find(|entry| entry.id == id)
-        .ok_or("That saved login no longer exists.")?;
-    if entry.username.is_empty() && entry.password.is_empty() {
-        return Err("This login has nothing saved to type.".to_string());
-    }
-    Ok((entry.username.clone(), entry.password.clone()))
-}
+use crate::vault::{TaggedItem, VaultResult, VaultState};
 
 #[tauri::command]
 pub fn auto_type(id: String, state: State<'_, VaultState>) -> VaultResult<()> {
@@ -26,7 +14,14 @@ pub fn auto_type(id: String, state: State<'_, VaultState>) -> VaultResult<()> {
             .lock()
             .map_err(|_| "Sesame could not read the vault session.".to_string())?;
         let session = session.as_ref().ok_or("Unlock your vault first.")?;
-        credentials_for(&session.payload, &id)?
+        let item = session.open_item(&id)?;
+        let TaggedItem::Login(entry) = &*item else {
+            return Err("That saved login no longer exists.".into());
+        };
+        if entry.username.is_empty() && entry.password.is_empty() {
+            return Err("This login has nothing saved to type.".to_string());
+        }
+        (entry.username.clone(), entry.password.clone())
     };
     let result = send_credentials(&username, &password);
     username.zeroize();

--- a/src-tauri/src/adapters/platform/external_url.rs
+++ b/src-tauri/src/adapters/platform/external_url.rs
@@ -91,12 +91,19 @@ pub fn open_external_url(
                 .lock()
                 .map_err(|_| "Sesame could not read the vault session.".to_string())?;
             let session = session.as_ref().ok_or("Unlock your vault first.")?;
-            if !session
-                .payload
-                .entries
-                .iter()
-                .any(|entry| entry_owns_url(entry, &parsed))
-            {
+            let index = session.snapshot();
+            let mut owned = false;
+            for summary in &index.entries {
+                let item = session.open_item(&summary.id)?;
+                let crate::vault::TaggedItem::Login(entry) = &*item else {
+                    return Err("That saved login no longer exists.".into());
+                };
+                if entry_owns_url(entry, &parsed) {
+                    owned = true;
+                    break;
+                }
+            }
+            if !owned {
                 return Err("That website is not attached to a saved login.".into());
             }
         }

--- a/src-tauri/src/browser_fill.rs
+++ b/src-tauri/src/browser_fill.rs
@@ -21,7 +21,7 @@ use crate::{
         IdentityFillFields, MAX_CREDENTIAL_FIELD_BYTES, MAX_NATIVE_MESSAGE_BYTES,
     },
     diagnostics,
-    vault::{random_id, Card, Identity, VaultEntry, VaultState},
+    vault::{random_id, Card, Identity, TaggedItem, VaultEntry, VaultState},
 };
 
 use crate::browser_host::HOST_FILE_NAME;
@@ -1216,7 +1216,13 @@ fn fill_response(app: &AppHandle, request: &BrowserRequest, peer: &PipePeer) -> 
             diagnostics::record_browser_host_registration(app, "fill_locked");
             return BrowserResponse::unavailable(&request.request_id, "locked");
         };
-        let candidates = matching_entries(&session.payload.entries, &origin);
+        let payload = match session.open_payload() {
+            Ok(payload) => payload,
+            Err(_) => {
+                return BrowserResponse::unavailable(&request.request_id, "approvalUnavailable")
+            }
+        };
+        let candidates = matching_entries(&payload.entries, &origin);
         (vault.session_epoch(), candidates)
     };
     if candidates.is_empty() {
@@ -1314,17 +1320,23 @@ fn fill_response(app: &AppHandle, request: &BrowserRequest, peer: &PipePeer) -> 
         emit_cancelled(app, &approval_id, "vaultChanged");
         return BrowserResponse::unavailable(&request.request_id, "locked");
     };
-    let Some(entry) = session.payload.entries.iter().find(|entry| {
-        entry.id == login_id
-            && NormalizedOrigin::from_saved_url(&entry.url)
-                .as_ref()
-                .and_then(|saved| origin_match_kind(saved, &origin))
-                .is_some()
-            && credential_fields_valid(entry)
-    }) else {
+    let Ok(item) = session.open_item(&login_id) else {
         emit_cancelled(app, &approval_id, "vaultChanged");
         return BrowserResponse::unavailable(&request.request_id, "staleRequest");
     };
+    let TaggedItem::Login(entry) = &*item else {
+        emit_cancelled(app, &approval_id, "vaultChanged");
+        return BrowserResponse::unavailable(&request.request_id, "staleRequest");
+    };
+    if NormalizedOrigin::from_saved_url(&entry.url)
+        .as_ref()
+        .and_then(|saved| origin_match_kind(saved, &origin))
+        .is_none()
+        || !credential_fields_valid(entry)
+    {
+        emit_cancelled(app, &approval_id, "vaultChanged");
+        return BrowserResponse::unavailable(&request.request_id, "staleRequest");
+    }
     BrowserResponse::fill_for(request, identity_value(entry), entry.password.clone())
 }
 
@@ -1379,9 +1391,18 @@ fn save_response(
             return BrowserResponse::save_unavailable(&request.request_id, "locked");
         };
         // `update` candidates come from the vault, never from the extension.
+        let payload = match session.open_payload() {
+            Ok(payload) => payload,
+            Err(_) => {
+                return BrowserResponse::save_unavailable(
+                    &request.request_id,
+                    "approvalUnavailable",
+                )
+            }
+        };
         let candidates = match kind {
             SaveKind::New => Vec::new(),
-            SaveKind::Update => matching_entries(&session.payload.entries, &origin),
+            SaveKind::Update => matching_entries(&payload.entries, &origin),
         };
         (vault.session_epoch(), candidates)
     };
@@ -1546,8 +1567,16 @@ fn card_response(app: &AppHandle, request: &BrowserRequest, peer: &PipePeer) -> 
             diagnostics::record_browser_host_registration(app, "card_locked");
             return BrowserResponse::card_unavailable(&request.request_id, "locked");
         };
-        let candidates = session
-            .payload
+        let payload = match session.open_payload() {
+            Ok(payload) => payload,
+            Err(_) => {
+                return BrowserResponse::card_unavailable(
+                    &request.request_id,
+                    "approvalUnavailable",
+                )
+            }
+        };
+        let candidates = payload
             .cards
             .iter()
             .filter(|card| card_supports_fields(card, &requested_fields))
@@ -1630,15 +1659,18 @@ fn card_response(app: &AppHandle, request: &BrowserRequest, peer: &PipePeer) -> 
         emit_card_cancelled(app, &approval_id, "vaultChanged");
         return BrowserResponse::card_unavailable(&request.request_id, "locked");
     };
-    let Some(card) = session
-        .payload
-        .cards
-        .iter()
-        .find(|card| card.id == card_id && card_supports_fields(card, &requested_fields))
-    else {
+    let Ok(item) = session.open_item(&card_id) else {
         emit_card_cancelled(app, &approval_id, "vaultChanged");
         return BrowserResponse::card_unavailable(&request.request_id, "staleRequest");
     };
+    let TaggedItem::Card(card) = &*item else {
+        emit_card_cancelled(app, &approval_id, "vaultChanged");
+        return BrowserResponse::card_unavailable(&request.request_id, "staleRequest");
+    };
+    if !card_supports_fields(card, &requested_fields) {
+        emit_card_cancelled(app, &approval_id, "vaultChanged");
+        return BrowserResponse::card_unavailable(&request.request_id, "staleRequest");
+    }
     BrowserResponse::card_for(request, selected_card_fields(card, &requested_fields))
 }
 

--- a/src-tauri/src/browser_fill_identity_approval.rs
+++ b/src-tauri/src/browser_fill_identity_approval.rs
@@ -31,8 +31,16 @@ fn identity_response(
             diagnostics::record_browser_host_registration(app, "identity_locked");
             return BrowserResponse::identity_unavailable(&request.request_id, "locked");
         };
-        let candidates: Vec<IdentityFillCandidate> = session
-            .payload
+        let payload = match session.open_payload() {
+            Ok(payload) => payload,
+            Err(_) => {
+                return BrowserResponse::identity_unavailable(
+                    &request.request_id,
+                    "approvalUnavailable",
+                )
+            }
+        };
+        let candidates: Vec<IdentityFillCandidate> = payload
             .identities
             .iter()
             .take(MAX_MATCHING_CANDIDATES)
@@ -129,12 +137,11 @@ fn identity_response(
         emit_identity_cancelled(app, &approval_id, "vaultChanged");
         return BrowserResponse::identity_unavailable(&request.request_id, "locked");
     };
-    let Some(identity) = session
-        .payload
-        .identities
-        .iter()
-        .find(|identity| identity.id == identity_id)
-    else {
+    let Ok(item) = session.open_item(&identity_id) else {
+        emit_identity_cancelled(app, &approval_id, "vaultChanged");
+        return BrowserResponse::identity_unavailable(&request.request_id, "staleRequest");
+    };
+    let TaggedItem::Identity(identity) = &*item else {
         emit_identity_cancelled(app, &approval_id, "vaultChanged");
         return BrowserResponse::identity_unavailable(&request.request_id, "staleRequest");
     };

--- a/src-tauri/src/commands/backups.rs
+++ b/src-tauri/src/commands/backups.rs
@@ -70,10 +70,8 @@ pub fn export_backup(
     }
     copy_private_file(&session.path, &destination)
         .map_err(|_| "Sesame could not write the encrypted backup to that location.".to_string())?;
-    if let (Some(vault_id), revision) = (
-        session.payload.vault_id.as_deref(),
-        session.payload.revision,
-    ) {
+    let snapshot = session.snapshot();
+    if let (Some(vault_id), revision) = (snapshot.vault_id.as_deref(), snapshot.revision) {
         let _ = recovery_health::update_after_export_with_payload(&app, vault_id, revision);
     }
     destination
@@ -110,14 +108,15 @@ pub fn export_vault_csv(
     if !parent.exists() {
         return Err("The selected export folder no longer exists.".into());
     }
-    let bytes = csv_export_bytes(&session.payload)?;
+    let payload = session.open_payload()?;
+    let bytes = csv_export_bytes(&payload)?;
     write_export_file(&destination, &bytes)?;
     let mut written = vec![backup_file_name(&destination)?];
 
-    if !session.payload.identities.is_empty() {
+    if !payload.identities.is_empty() {
         let identities_destination = identities_export_path(&destination)
             .ok_or("Sesame could not name the exported identities file.")?;
-        let identities_bytes = identities_csv_bytes(&session.payload)?;
+        let identities_bytes = identities_csv_bytes(&payload)?;
         write_export_file(&identities_destination, &identities_bytes)?;
         written.push(backup_file_name(&identities_destination)?);
     }
@@ -262,11 +261,14 @@ pub fn verify_backup(
     let result = verify_backup_file(&source, &secret);
     secret.zeroize();
     let verification = result?;
-    let current_vault_id = state.session.lock().ok().and_then(|session| {
-        session
-            .as_ref()
-            .and_then(|vault| vault.payload.vault_id.clone())
-    });
+    let current_vault_id = state
+        .session
+        .lock()
+        .map_err(|_| "Sesame could not read the vault session.".to_string())?
+        .as_ref()
+        .map(|vault| vault.open_payload())
+        .transpose()?
+        .and_then(|payload| payload.vault_id.clone());
     if let (Some(vault_id), Some(current_id)) = (
         verification.vault_id.as_deref(),
         current_vault_id.as_deref(),
@@ -326,10 +328,14 @@ pub fn get_recovery_health(
     app: AppHandle,
     state: State<'_, VaultState>,
 ) -> VaultResult<recovery_health::RecoveryHealth> {
-    let current_id = state
+    let session = state
         .session
         .lock()
-        .ok()
-        .and_then(|session| session.as_ref().and_then(|s| s.payload.vault_id.clone()));
+        .map_err(|_| "Sesame could not read the vault session.".to_string())?;
+    let current_id = session
+        .as_ref()
+        .map(|vault| vault.open_payload())
+        .transpose()?
+        .and_then(|payload| payload.vault_id.clone());
     recovery_health::get_health(&app, current_id.as_deref())
 }

--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -2,7 +2,6 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use tauri::State;
 
 use crate::commands::record_commands::impl_record_commands;
-use crate::vault::snapshot::snapshot_for;
 use crate::vault::types::{
     Attachment, DeleteDocumentMetadataResult, DocumentMetadata, DocumentMetadataInput,
     SaveDocumentMetadataResult,
@@ -150,7 +149,8 @@ pub fn add_document_attachment(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before adding an attachment.")?;
-    let mut next_payload = session.payload.clone();
+    let payload = session.open_payload()?;
+    let mut next_payload = payload.clone();
     let index = next_payload
         .documents
         .iter()
@@ -170,7 +170,7 @@ pub fn add_document_attachment(
     state.advance_session_epoch();
     Ok(SaveDocumentMetadataResult {
         id: document_id,
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
     })
 }
 
@@ -187,7 +187,8 @@ pub fn remove_document_attachment(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before removing an attachment.")?;
-    let mut next_payload = session.payload.clone();
+    let payload = session.open_payload()?;
+    let mut next_payload = payload.clone();
     let index = next_payload
         .documents
         .iter()
@@ -206,6 +207,6 @@ pub fn remove_document_attachment(
     state.advance_session_epoch();
     Ok(SaveDocumentMetadataResult {
         id: document_id,
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
     })
 }

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -3,8 +3,7 @@
 
 use tauri::State;
 
-use crate::vault::history::{history_version_preview, restore_version};
-use crate::vault::snapshot::snapshot_for;
+use crate::vault::history::restore_version;
 use crate::vault::types::{ItemPreview, RestoreHistoryVersionResult};
 use crate::vault::{VaultResult, VaultState};
 
@@ -23,7 +22,7 @@ pub fn preview_history_version(
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    history_version_preview(&session.payload, id)
+    session.history_item_preview(id)
 }
 
 #[tauri::command]
@@ -42,11 +41,12 @@ pub fn restore_history_version(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before restoring a version.")?;
-    let (next_payload, restored_id) = restore_version(&session.payload, id)?;
+    let payload = session.open_payload()?;
+    let (next_payload, restored_id) = restore_version(&payload, id)?;
     crate::vault::storage::commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
     Ok(RestoreHistoryVersionResult {
         restored_id,
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
     })
 }

--- a/src-tauri/src/commands/imports.rs
+++ b/src-tauri/src/commands/imports.rs
@@ -7,7 +7,7 @@ use crate::vault::imports::{parse_import_entries, read_import_file, validate_imp
 use crate::vault::pending_import::{take_matching, PendingImport};
 use crate::vault::snapshot::{
     duplicate_key, entries_by_duplicate_key, existing_import_relation, is_duplicate_key_eligible,
-    should_skip_exact_duplicate, snapshot_for,
+    should_skip_exact_duplicate,
 };
 use crate::vault::storage::{commit_payload_change, materialize_entry_folder};
 use crate::vault::{
@@ -104,7 +104,8 @@ pub fn preview_import(
     let session = session
         .as_ref()
         .ok_or("Unlock your vault before importing.")?;
-    let existing_by_key = entries_by_duplicate_key(&session.payload.entries);
+    let payload = session.open_payload()?;
+    let existing_by_key = entries_by_duplicate_key(&payload.entries);
     let mut seen_import_keys = HashSet::new();
     let mut exact_duplicates = 0;
     let mut account_conflicts = 0;
@@ -177,7 +178,8 @@ pub fn commit_import(
         take_matching(&mut slot, import_id.trim())?.into_parts()
     };
     let revision_backup_name = snapshot_vault_revision(&session.path, "import")?;
-    let existing_by_key = entries_by_duplicate_key(&session.payload.entries);
+    let payload = session.open_payload()?;
+    let existing_by_key = entries_by_duplicate_key(&payload.entries);
     let mut skipped_exact_duplicates = 0;
     let entries = if skip_exact_duplicates {
         imported
@@ -199,7 +201,7 @@ pub fn commit_import(
     let imported_identities = identities.len();
     let imported_ssh_keys = ssh_keys.len();
     // No duplicate-key model for notes, cards, identities, and SSH keys: every one is kept.
-    let mut next_payload = session.payload.clone();
+    let mut next_payload = payload.clone();
     insert_imported_items(
         &mut next_payload,
         entries,
@@ -211,7 +213,7 @@ pub fn commit_import(
     commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
     Ok(ImportResult {
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
         imported_secure_notes,
         imported_cards,
         imported_identities,

--- a/src-tauri/src/commands/items.rs
+++ b/src-tauri/src/commands/items.rs
@@ -2,10 +2,8 @@
 //! snapshot deliberately omits usernames, network names, and note contents;
 //! only the ids of the matches cross back to the interface.
 
+use crate::vault::{Folder, TaggedItem, VaultResult, VaultState};
 use tauri::State;
-
-use crate::vault::snapshot::folder_name;
-use crate::vault::{TaggedItem, VaultPayload, VaultResult, VaultState};
 
 #[tauri::command]
 pub fn search_items(query: String, state: State<'_, VaultState>) -> VaultResult<Vec<String>> {
@@ -18,23 +16,30 @@ pub fn search_items(query: String, state: State<'_, VaultState>) -> VaultResult<
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    let payload = &session.payload;
-    Ok(payload
-        .item_views()
-        .into_iter()
-        .filter(|item| item_matches_search(payload, item, &needle))
-        .map(|item| item.id().to_string())
-        .collect())
+    let index = session.snapshot();
+    let mut matches = Vec::new();
+    for id in index
+        .entries
+        .iter()
+        .map(|item| item.id.as_str())
+        .chain(index.items.iter().map(|item| item.id.as_str()))
+    {
+        let item = session.open_item(id)?;
+        if item_matches_search(&index.folders, &item, &needle) {
+            matches.push(id.to_string());
+        }
+    }
+    Ok(matches)
 }
 
-fn item_matches_search(payload: &VaultPayload, item: &TaggedItem, needle: &str) -> bool {
+fn item_matches_search(folders: &[Folder], item: &TaggedItem, needle: &str) -> bool {
     let metadata = item.metadata();
     if metadata.item_title().to_lowercase().contains(needle)
         || metadata
             .item_tags()
             .iter()
             .any(|tag| tag.to_lowercase().contains(needle))
-        || folder_name(payload, metadata.item_folder_id())
+        || folder_name(folders, metadata.item_folder_id())
             .to_lowercase()
             .contains(needle)
     {
@@ -43,6 +48,12 @@ fn item_matches_search(payload: &VaultPayload, item: &TaggedItem, needle: &str) 
     searchable_fields(item)
         .iter()
         .any(|field| field.to_lowercase().contains(needle))
+}
+
+fn folder_name(folders: &[Folder], id: Option<&str>) -> String {
+    id.and_then(|id| folders.iter().find(|folder| folder.id == id))
+        .map(|folder| folder.name.clone())
+        .unwrap_or_default()
 }
 
 /// Everything a search may read. Passwords, keys, licence keys, security
@@ -90,5 +101,40 @@ fn searchable_fields(item: &TaggedItem) -> Vec<&str> {
             fields.extend(record.fields.iter().map(|field| field.label.as_str()));
             fields
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::VaultEntry;
+
+    fn login() -> TaggedItem {
+        TaggedItem::Login(VaultEntry {
+            id: "fictional-login".to_string(),
+            title: "Northwind".to_string(),
+            username: "casey".to_string(),
+            password: "fictional-secret-canary".to_string(),
+            folder_id: Some("fictional-folder".to_string()),
+            ..VaultEntry::default()
+        })
+    }
+
+    #[test]
+    fn search_matches_allowed_record_fields_and_redacted_folders() {
+        let folders = vec![Folder {
+            id: "fictional-folder".to_string(),
+            name: "Work".to_string(),
+        }];
+        let item = login();
+
+        assert!(item_matches_search(&folders, &item, "north"));
+        assert!(item_matches_search(&folders, &item, "casey"));
+        assert!(item_matches_search(&folders, &item, "work"));
+    }
+
+    #[test]
+    fn search_does_not_match_secret_fields() {
+        assert!(!item_matches_search(&[], &login(), "secret-canary"));
     }
 }

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -5,7 +5,6 @@ use tauri::{AppHandle, State};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::vault::crypto::decrypt_bytes;
-use crate::vault::snapshot::snapshot_for;
 use crate::vault::storage::{
     check_supported_vault_format, clear_pin_throttle_state, complete_recovery_setup_for_session,
     derive_pin_wrapping_key, persist_session, read_pin_throttle_state, remove_hello_for_session,
@@ -51,16 +50,16 @@ pub fn get_vault_status(app: AppHandle, state: State<'_, VaultState>) -> VaultRe
         .lock()
         .map_err(|_| "Sesame could not read the vault state.".to_string())?;
     let unlocked = session.is_some();
-    let (vault_id, revision, onboarding_required) = session
-        .as_ref()
-        .map(|s| {
-            (
-                s.payload.vault_id.clone(),
-                s.payload.revision,
-                !s.setup_complete,
-            )
-        })
-        .unwrap_or_default();
+    let (vault_id, revision, onboarding_required) = if let Some(session) = session.as_ref() {
+        let snapshot = session.snapshot();
+        (
+            snapshot.vault_id,
+            snapshot.revision,
+            !session.setup_complete,
+        )
+    } else {
+        Default::default()
+    };
     drop(session);
 
     Ok(VaultStatus {
@@ -134,21 +133,10 @@ pub fn create_vault(
     state.cache_hello_unlock(false);
     let _ = establish_pin_throttle_state(&app, &state);
 
-    let snapshot = snapshot_for(&opened.payload);
     // `OpenedVault` zeroizes on drop, so clone and let it drop rather than moving fields out.
-    *session = Some(UnlockedVault {
-        path,
-        key: opened.key.clone(),
-        kdf: opened.file.kdf.clone(),
-        key_wrap: opened.file.key_wrap.clone(),
-        legacy_device_wrap: None,
-        recovery_kdf: opened.file.recovery_kdf.clone(),
-        recovery_wrap: opened.file.recovery_wrap.clone(),
-        pin_wrap: None,
-        hello_wrap: None,
-        setup_complete: opened.file.setup_complete,
-        payload: opened.payload.clone(),
-    });
+    let unlocked = UnlockedVault::from_opened(path, &opened)?;
+    let snapshot = unlocked.snapshot();
+    *session = Some(unlocked);
     state.advance_session_epoch();
     Ok(VaultSetup {
         snapshot,
@@ -167,21 +155,8 @@ fn install_unlocked_session(
     let opened = sesame_core::api::open_vault_with_key(&file, key_array)?;
     let pin_unlock_available = opened.file.pin_wrap.is_some();
     let hello_unlock_available = opened.file.hello_wrap.is_some();
-    let snapshot = snapshot_for(&opened.payload);
     // Same zeroize-on-drop workaround `create_vault` uses.
-    let mut unlocked = UnlockedVault {
-        path,
-        key: opened.key.clone(),
-        kdf: opened.file.kdf.clone(),
-        key_wrap: opened.file.key_wrap.clone(),
-        legacy_device_wrap: opened.file.legacy_device_wrap.clone(),
-        recovery_kdf: opened.file.recovery_kdf.clone(),
-        recovery_wrap: opened.file.recovery_wrap.clone(),
-        pin_wrap: opened.file.pin_wrap.clone(),
-        hello_wrap: opened.file.hello_wrap.clone(),
-        setup_complete: opened.file.setup_complete,
-        payload: opened.payload.clone(),
-    };
+    let mut unlocked = UnlockedVault::from_opened(path, &opened)?;
     if opened.migrated {
         if let Err(error) = persist_session(&mut unlocked) {
             return Err(format!(
@@ -189,6 +164,7 @@ fn install_unlocked_session(
             ));
         }
     }
+    let snapshot = unlocked.snapshot();
     *session = Some(unlocked);
     // Fresh session epoch invalidates approvals bound to the previous one.
     state.advance_session_epoch();

--- a/src-tauri/src/commands/logins.rs
+++ b/src-tauri/src/commands/logins.rs
@@ -4,7 +4,7 @@ use tauri::State;
 
 use crate::vault::backup::snapshot_vault_revision;
 use crate::vault::imports::{entry_from_input, resolved_totp};
-use crate::vault::snapshot::{current_totp, login_card_for, login_summary_for, snapshot_for};
+use crate::vault::snapshot::{current_totp, login_card_for, login_summary_for};
 use crate::vault::storage::{
     commit_payload_change, materialize_entry_folder, payload_with_item_favourite,
     payload_with_item_folder_id, payload_with_recorded_item_use, payload_without_login,
@@ -23,7 +23,7 @@ pub fn get_vault_snapshot(state: State<'_, VaultState>) -> VaultResult<VaultSnap
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    Ok(snapshot_for(&session.payload))
+    Ok(session.snapshot())
 }
 
 /// Small on purpose: a shortcut for retyping an address, not a directory.
@@ -40,32 +40,29 @@ pub fn suggest_field_values(
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    Ok(suggested_values(&session.payload, &field))
-}
-
-fn suggested_values(payload: &VaultPayload, field: &str) -> Vec<String> {
-    let values: Box<dyn Iterator<Item = &str>> = match field {
-        "username" => Box::new(payload.entries.iter().map(|entry| entry.username.as_str())),
-        "email" => Box::new(
-            payload
-                .entries
-                .iter()
-                .map(|entry| entry.email.as_str())
-                .chain(
-                    payload
-                        .identities
-                        .iter()
-                        .map(|identity| identity.email.as_str()),
-                ),
-        ),
-        // An unknown field must not fall back to another field's values.
-        _ => return Vec::new(),
-    };
+    if !matches!(field.as_str(), "username" | "email") {
+        return Ok(Vec::new());
+    }
+    let index = session.snapshot();
+    let ids = index.entries.iter().map(|item| item.id.as_str()).chain(
+        index
+            .items
+            .iter()
+            .filter(|item| field == "email" && item.kind == "identity")
+            .map(|item| item.id.as_str()),
+    );
     let mut seen = HashSet::new();
     let mut suggestions = Vec::new();
-    for value in values {
+    for id in ids {
+        let item = session.open_item(id)?;
+        let value = match (&*item, field.as_str()) {
+            (TaggedItem::Login(entry), "username") => entry.username.as_str(),
+            (TaggedItem::Login(entry), "email") => entry.email.as_str(),
+            (TaggedItem::Identity(identity), "email") => identity.email.as_str(),
+            _ => continue,
+        };
         let trimmed = value.trim();
-        if trimmed.is_empty() || !seen.insert(trimmed) {
+        if trimmed.is_empty() || !seen.insert(trimmed.to_string()) {
             continue;
         }
         suggestions.push(trimmed.to_string());
@@ -73,7 +70,7 @@ fn suggested_values(payload: &VaultPayload, field: &str) -> Vec<String> {
             break;
         }
     }
-    suggestions
+    Ok(suggestions)
 }
 
 #[tauri::command]
@@ -86,13 +83,12 @@ pub fn get_login_card(
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    let entry = session
-        .payload
-        .entries
-        .iter()
-        .find(|entry| entry.id == id)
-        .ok_or("That saved login no longer exists.")?;
-    Ok(login_card_for(&session.payload, entry))
+    let item = session.open_item(&id)?;
+    let TaggedItem::Login(entry) = &*item else {
+        return Err("That saved login no longer exists.".into());
+    };
+    let index = session.snapshot();
+    Ok(login_card_for(&index.folders, entry))
 }
 
 #[tauri::command]
@@ -105,12 +101,10 @@ pub fn get_login_summary(
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    let entry = session
-        .payload
-        .entries
-        .iter()
-        .find(|entry| entry.id == id)
-        .ok_or("That saved login no longer exists.")?;
+    let item = session.open_item(&id)?;
+    let TaggedItem::Login(entry) = &*item else {
+        return Err("That saved login no longer exists.".into());
+    };
     Ok(login_summary_for(entry))
 }
 
@@ -123,8 +117,17 @@ pub fn get_duplicate_groups(
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    Ok(crate::vault::snapshot::duplicate_groups_for(
-        &session.payload,
+    let index = session.snapshot();
+    let mut summaries = Vec::with_capacity(index.entries.len());
+    for indexed in &index.entries {
+        let item = session.open_item(&indexed.id)?;
+        let TaggedItem::Login(entry) = &*item else {
+            return Err("That saved login no longer exists.".into());
+        };
+        summaries.push(login_summary_for(entry));
+    }
+    Ok(crate::vault::snapshot::duplicate_groups_from_summaries(
+        summaries,
     ))
 }
 
@@ -139,8 +142,13 @@ pub fn list_totp_codes(
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
+    let index = session.snapshot();
     let mut codes = Vec::new();
-    for entry in &session.payload.entries {
+    for summary in &index.entries {
+        let item = session.open_item(&summary.id)?;
+        let TaggedItem::Login(entry) = &*item else {
+            return Err("That saved login no longer exists.".into());
+        };
         let Some((code, remaining, period)) = entry.totp.as_deref().and_then(current_totp) else {
             continue;
         };
@@ -168,12 +176,10 @@ pub fn refresh_totp(
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    let entry = session
-        .payload
-        .entries
-        .iter()
-        .find(|entry| entry.id == id)
-        .ok_or("That saved login no longer exists.")?;
+    let item = session.open_item(&id)?;
+    let TaggedItem::Login(entry) = &*item else {
+        return Err("That saved login no longer exists.".into());
+    };
     let (totp_code, totp_remaining) = entry
         .totp
         .as_deref()
@@ -199,7 +205,8 @@ pub fn save_login(input: LoginInput, state: State<'_, VaultState>) -> VaultResul
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before saving a login.")?;
-    let mut next_payload = session.payload.clone();
+    let payload = session.open_payload()?;
+    let mut next_payload = payload.clone();
     materialize_entry_folder(&mut next_payload, &mut entry)?;
     if let Some(existing) = next_payload
         .entries
@@ -234,7 +241,7 @@ pub fn save_login(input: LoginInput, state: State<'_, VaultState>) -> VaultResul
     state.advance_session_epoch();
     Ok(SaveLoginResult {
         id: entry_id,
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
     })
 }
 
@@ -253,11 +260,11 @@ pub fn set_login_folders(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before organizing logins.")?;
-    let next_payload =
-        crate::vault::storage::payload_with_login_folders(&session.payload, &ids, &folder)?;
+    let payload = session.open_payload()?;
+    let next_payload = crate::vault::storage::payload_with_login_folders(&payload, &ids, &folder)?;
     commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
-    Ok(snapshot_for(&session.payload))
+    Ok(session.snapshot())
 }
 
 #[tauri::command]
@@ -274,10 +281,11 @@ pub fn bulk_assign_folder(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before organizing items.")?;
-    let next_payload = payload_with_item_folder_id(&session.payload, &ids, folder_id.as_deref())?;
+    let payload = session.open_payload()?;
+    let next_payload = payload_with_item_folder_id(&payload, &ids, folder_id.as_deref())?;
     commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
-    Ok(snapshot_for(&session.payload))
+    Ok(session.snapshot())
 }
 
 #[tauri::command]
@@ -319,10 +327,11 @@ fn change_folders(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before organizing folders.")?;
-    let next_payload = change(&session.payload)?;
+    let payload = session.open_payload()?;
+    let next_payload = change(&payload)?;
     commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
-    Ok(snapshot_for(&session.payload))
+    Ok(session.snapshot())
 }
 
 fn checked_item_ids(ids: Vec<String>) -> VaultResult<HashSet<String>> {
@@ -352,10 +361,11 @@ pub fn set_item_favourite(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before changing a favourite.")?;
-    let next_payload = payload_with_item_favourite(&session.payload, id.trim(), favourite)?;
+    let payload = session.open_payload()?;
+    let next_payload = payload_with_item_favourite(&payload, id.trim(), favourite)?;
     commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
-    Ok(snapshot_for(&session.payload))
+    Ok(session.snapshot())
 }
 
 #[tauri::command]
@@ -367,10 +377,11 @@ pub fn record_item_use(id: String, state: State<'_, VaultState>) -> VaultResult<
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before recording item use.")?;
-    let next_payload = payload_with_recorded_item_use(&session.payload, id.trim())?;
+    let payload = session.open_payload()?;
+    let next_payload = payload_with_recorded_item_use(&payload, id.trim())?;
     commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
-    Ok(snapshot_for(&session.payload))
+    Ok(session.snapshot())
 }
 
 #[tauri::command]
@@ -386,20 +397,20 @@ pub fn delete_login(id: String, state: State<'_, VaultState>) -> VaultResult<Del
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before deleting a login.")?;
-    let entry = session
-        .payload
+    let payload = session.open_payload()?;
+    let entry = payload
         .entries
         .iter()
         .find(|entry| entry.id == id)
         .cloned()
         .ok_or("That saved login no longer exists.")?;
-    let mut next_payload = payload_without_login(&session.payload, id)?;
+    let mut next_payload = payload_without_login(&payload, id)?;
     trash_item(&mut next_payload, TaggedItem::Login(entry));
     commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
     Ok(DeleteLoginResult {
         deleted_id: id.to_string(),
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
     })
 }
 
@@ -427,8 +438,9 @@ pub fn merge_duplicate_logins(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before merging logins.")?;
+    let payload = session.open_payload()?;
     let next_payload = crate::vault::storage::merged_duplicate_payload(
-        &session.payload,
+        &payload,
         &keep_id,
         &remove_ids,
         &request.choices,
@@ -438,7 +450,7 @@ pub fn merge_duplicate_logins(
     state.advance_session_epoch();
     Ok(MergeDuplicateLoginsResult {
         id: keep_id,
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
         revision_backup_name,
     })
 }
@@ -456,15 +468,16 @@ pub fn get_merge_comparison(
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    let mut group = Vec::with_capacity(ids.len());
+    let mut opened = Vec::with_capacity(ids.len());
     for id in &ids {
-        let entry = session
-            .payload
-            .entries
-            .iter()
-            .find(|entry| entry.id == id.trim())
-            .ok_or("One of those logins no longer exists.")?;
-        group.push(entry);
+        opened.push(session.open_item(id.trim())?);
     }
+    let group = opened
+        .iter()
+        .map(|item| match &**item {
+            TaggedItem::Login(entry) => Ok(entry),
+            _ => Err("One of those logins no longer exists.".to_string()),
+        })
+        .collect::<VaultResult<Vec<_>>>()?;
     Ok(crate::vault::snapshot::merge_comparison_for(&group))
 }

--- a/src-tauri/src/commands/quick_access.rs
+++ b/src-tauri/src/commands/quick_access.rs
@@ -9,7 +9,7 @@ use crate::adapters::platform::desktop_shell::show_main_window;
 use crate::vault::snapshot::current_totp;
 use crate::vault::storage::vault_path;
 use crate::vault::util::initials_for;
-use crate::vault::{Identity, TaggedItem, VaultPayload, VaultResult, VaultState};
+use crate::vault::{Identity, TaggedItem, VaultResult, VaultState};
 
 const QUICK_ACCESS_WINDOW: &str = "quick-access";
 const QUICK_ACCESS_RESULT_LIMIT: usize = 8;
@@ -95,7 +95,23 @@ pub fn search_quick_access_items(
     let session = session
         .as_ref()
         .ok_or("Unlock your vault in Sesame first.")?;
-    Ok(quick_access_items(&session.payload, &query))
+    let index = session.snapshot();
+    let needle = query.trim().to_lowercase();
+    let mut items = Vec::new();
+    for id in index
+        .entries
+        .iter()
+        .map(|item| item.id.as_str())
+        .chain(index.items.iter().map(|item| item.id.as_str()))
+    {
+        let item = session.open_item(id)?;
+        if quick_access_matches(&item, &needle) {
+            items.push(quick_access_item(&item));
+        }
+    }
+    items.sort_by_key(|item| item.title.to_lowercase());
+    items.truncate(QUICK_ACCESS_RESULT_LIMIT);
+    Ok(items)
 }
 
 #[tauri::command]
@@ -114,10 +130,7 @@ pub fn get_quick_access_field(
     let session = session
         .as_ref()
         .ok_or("Unlock your vault in Sesame first.")?;
-    let item = session
-        .payload
-        .active_item(id.trim())
-        .ok_or("That saved item no longer exists.")?;
+    let item = session.open_item(id.trim())?;
     let action = quick_access_actions(&item)
         .into_iter()
         .find(|action| action.field == field.trim())
@@ -149,9 +162,7 @@ pub fn open_quick_access_item(
         let session = session
             .as_ref()
             .ok_or("Unlock your vault in Sesame first.")?;
-        if session.payload.active_item(&id).is_none() {
-            return Err("That saved item no longer exists.".into());
-        }
+        session.open_item(&id)?;
     }
     let _ = window.hide();
     show_main_window(&app);
@@ -159,28 +170,17 @@ pub fn open_quick_access_item(
         .map_err(|_| "Sesame could not open that item in the main window.".to_string())
 }
 
-fn quick_access_items(payload: &VaultPayload, query: &str) -> Vec<QuickAccessItem> {
-    let needle = query.trim().to_lowercase();
-    let mut items: Vec<QuickAccessItem> = payload
-        .item_views()
-        .into_iter()
-        .filter(|item| quick_access_matches(item, &needle))
-        .map(|item| {
-            let actions = quick_access_actions(&item);
-            let preview = item.preview();
-            QuickAccessItem {
-                id: item.id().to_string(),
-                kind: item.kind(),
-                initials: initials_for(&preview.title),
-                title: preview.title,
-                subtitle: preview.detail.unwrap_or_default(),
-                actions,
-            }
-        })
-        .collect();
-    items.sort_by_key(|item| item.title.to_lowercase());
-    items.truncate(QUICK_ACCESS_RESULT_LIMIT);
-    items
+fn quick_access_item(item: &TaggedItem) -> QuickAccessItem {
+    let actions = quick_access_actions(item);
+    let preview = item.preview();
+    QuickAccessItem {
+        id: item.id().to_string(),
+        kind: item.kind(),
+        initials: initials_for(&preview.title),
+        title: preview.title,
+        subtitle: preview.detail.unwrap_or_default(),
+        actions,
+    }
 }
 
 fn quick_access_matches(item: &TaggedItem, needle: &str) -> bool {
@@ -343,4 +343,36 @@ fn quick_access_value(item: &TaggedItem, field: &str) -> Option<String> {
         _ => String::new(),
     };
     (!value.trim().is_empty()).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::VaultEntry;
+
+    fn login() -> TaggedItem {
+        TaggedItem::Login(VaultEntry {
+            id: "fictional-login".to_string(),
+            title: "Northwind".to_string(),
+            username: "casey".to_string(),
+            password: "fictional-secret-canary".to_string(),
+            ..VaultEntry::default()
+        })
+    }
+
+    #[test]
+    fn quick_access_result_is_redacted_after_one_record_is_opened() {
+        let result = quick_access_item(&login());
+        let serialized = serde_json::to_string(&result).expect("serialized quick access item");
+
+        assert!(serialized.contains("Northwind"));
+        assert!(serialized.contains("Copy password"));
+        assert!(!serialized.contains("fictional-secret-canary"));
+    }
+
+    #[test]
+    fn quick_access_search_does_not_match_secret_values() {
+        assert!(quick_access_matches(&login(), "casey"));
+        assert!(!quick_access_matches(&login(), "secret-canary"));
+    }
 }

--- a/src-tauri/src/commands/record_commands.rs
+++ b/src-tauri/src/commands/record_commands.rs
@@ -48,8 +48,9 @@ macro_rules! impl_record_commands {
                 .lock()
                 .map_err(|_| "Sesame could not read the vault session.".to_string())?;
             let session = session.as_ref().ok_or("Unlock your vault first.")?;
-            match session.payload.active_item(&id) {
-                Some(crate::vault::types::TaggedItem::$Variant(item)) => Ok(item),
+            let item = session.open_item(&id)?;
+            match &*item {
+                crate::vault::types::TaggedItem::$Variant(item) => Ok(item.clone()),
                 _ => Err(format!("That saved {} no longer exists.", $missing_noun)),
             }
         }
@@ -66,7 +67,8 @@ macro_rules! impl_record_commands {
                 .lock()
                 .map_err(|_| "Sesame could not read the vault session.".to_string())?;
             let session = session.as_mut().ok_or($save_unlock_msg)?;
-            let mut next_payload = session.payload.clone();
+            let payload = session.open_payload()?;
+            let mut next_payload = payload.clone();
             if let Some(previous) = next_payload.take_active_item(&item_id) {
                 let crate::vault::types::TaggedItem::$Variant(existing) = previous else {
                     return Err("That item id belongs to a different kind of saved item.".into());
@@ -90,7 +92,7 @@ macro_rules! impl_record_commands {
             state.advance_session_epoch();
             Ok($SaveResult {
                 id: item_id,
-                snapshot: crate::vault::snapshot::snapshot_for(&session.payload),
+                snapshot: session.snapshot(),
             })
         }
 
@@ -108,7 +110,8 @@ macro_rules! impl_record_commands {
                 .lock()
                 .map_err(|_| "Sesame could not read the vault session.".to_string())?;
             let session = session.as_mut().ok_or($delete_unlock_msg)?;
-            let mut next_payload = session.payload.clone();
+            let payload = session.open_payload()?;
+            let mut next_payload = payload.clone();
             let item = match next_payload.take_active_item(id) {
                 Some(crate::vault::types::TaggedItem::$Variant(item)) => item,
                 Some(_) => {
@@ -121,7 +124,7 @@ macro_rules! impl_record_commands {
             state.advance_session_epoch();
             Ok($DeleteResult {
                 deleted_id: id.to_string(),
-                snapshot: crate::vault::snapshot::snapshot_for(&session.payload),
+                snapshot: session.snapshot(),
             })
         }
     };

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -2,7 +2,6 @@ use tauri::{AppHandle, State};
 
 use crate::browser_fill::SaveKind;
 use crate::vault::imports::entry_from_input;
-use crate::vault::snapshot::snapshot_for;
 use crate::vault::storage::commit_payload_change;
 use crate::vault::types::TaggedItem;
 use crate::vault::util::unix_timestamp;
@@ -141,13 +140,14 @@ fn save_new_login(
                 .to_string(),
         );
     }
-    let mut next_payload = session.payload.clone();
+    let current = session.open_payload()?;
+    let mut next_payload = current.clone();
     next_payload.entries.push(entry);
     commit_payload_change(session, next_payload)?;
     vault.advance_session_epoch();
     Ok(SaveLoginResult {
         id: entry_id,
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
     })
 }
 
@@ -182,11 +182,12 @@ fn save_login_update(
         );
     }
     // Re-verified under the lock: still exactly this origin's saved login.
-    if !browser_fill::verify_update_target(&session.payload.entries, &payload.origin, &target_id) {
+    let current = session.open_payload()?;
+    if !browser_fill::verify_update_target(&current.entries, &payload.origin, &target_id) {
         return Err("That saved login no longer matches this site.".to_string());
     }
 
-    let mut next_payload = session.payload.clone();
+    let mut next_payload = current.clone();
     let Some(existing) = next_payload
         .entries
         .iter_mut()
@@ -203,7 +204,7 @@ fn save_login_update(
     vault.advance_session_epoch();
     Ok(SaveLoginResult {
         id: target_id,
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
     })
 }
 

--- a/src-tauri/src/commands/sync_adopt.rs
+++ b/src-tauri/src/commands/sync_adopt.rs
@@ -161,10 +161,11 @@ pub(super) fn adopt(
         std::mem::replace(&mut vault.recovery_wrap, Some(recovery_wrap)),
         std::mem::replace(&mut vault.pin_wrap, None),
         std::mem::replace(&mut vault.key, zeroize::Zeroizing::new(key)),
-        std::mem::replace(&mut vault.payload, payload),
     );
 
-    if let Err(error) = crate::vault::storage::persist_session_without_previous(vault) {
+    if let Err(error) =
+        crate::vault::storage::commit_payload_change_without_previous(vault, payload)
+    {
         // Nothing partially applied: a failed write restores the old key and contents.
         vault.kdf = previous.0;
         vault.key_wrap = previous.1;
@@ -172,7 +173,6 @@ pub(super) fn adopt(
         vault.recovery_wrap = previous.3;
         vault.pin_wrap = previous.4;
         vault.key = previous.5;
-        vault.payload = previous.6;
         return Err(error);
     }
     Ok(shown)

--- a/src-tauri/src/commands/sync_transfer.rs
+++ b/src-tauri/src/commands/sync_transfer.rs
@@ -53,7 +53,8 @@ pub(super) async fn approve_frozen_device(
         let vault = session
             .as_ref()
             .ok_or("Unlock Sesame before approving a device.")?;
-        if vault.payload.vault_id.as_deref() != Some(vault_id) {
+        let payload = vault.open_payload()?;
+        if payload.vault_id.as_deref() != Some(vault_id) {
             return Err("That approval was prepared for a different vault.".into());
         }
         crate::sync::keys::seal_vault_key(vault.key.as_ref(), &recipient_key, &current.vault_id)?
@@ -141,11 +142,12 @@ pub async fn sync_upload_vault(
             .lock()
             .map_err(|_| "Sesame could not read the unlocked vault.".to_string())?;
         let vault = session.as_ref().ok_or("Unlock Sesame before syncing.")?;
-        let plaintext = serde_json::to_vec(&vault.payload)
+        let payload = vault.open_payload()?;
+        let plaintext = serde_json::to_vec(&*payload)
             .map_err(|_| "Sesame could not prepare the vault for sync.".to_string())?;
         let digest = crate::sync::state::payload_digest(&plaintext);
         let blob = crate::vault::crypto::encrypt_bytes(&vault.key, &plaintext, &aad)?;
-        (blob, vault.payload.entries.len(), digest)
+        (blob, payload.entries.len(), digest)
     };
 
     let nonce = decode_bytes(&blob.nonce)?;
@@ -234,7 +236,8 @@ pub async fn sync_download_vault(
         let vault = session.as_mut().ok_or("Unlock Sesame before syncing.")?;
 
         // An ordinary pull replaces the vault, so it must not run over edits never uploaded.
-        let local = serde_json::to_vec(&vault.payload)
+        let payload = vault.open_payload()?;
+        let local = serde_json::to_vec(&*payload)
             .map_err(|_| "Sesame could not read the local vault.".to_string())?;
         if base.has_local_changes(&local) {
             return Err(
@@ -389,7 +392,8 @@ pub async fn sync_remove_device(
             .lock()
             .map_err(|_| "Sesame could not read the unlocked vault.".to_string())?;
         let vault = session.as_ref().ok_or("Unlock Sesame before syncing.")?;
-        if vault.payload.vault_id.as_deref() != Some(current.vault_id.as_str()) {
+        let payload = vault.open_payload()?;
+        if payload.vault_id.as_deref() != Some(current.vault_id.as_str()) {
             return Err("The unlocked vault is not the Sync vault for this account.".into());
         }
         // Verify the current wrapper before asking the service to commit: a mistype must not orphan every path.
@@ -408,7 +412,7 @@ pub async fn sync_remove_device(
         if !matches {
             return Err("That master password is not correct.".into());
         }
-        let plaintext = serde_json::to_vec(&vault.payload)
+        let plaintext = serde_json::to_vec(&*payload)
             .map_err(|_| "Sesame could not prepare the vault for sync.".to_string())?;
         let blob = crate::vault::crypto::encrypt_bytes(
             &new_key,
@@ -425,7 +429,7 @@ pub async fn sync_remove_device(
         )?;
         (
             blob,
-            vault.payload.entries.len(),
+            payload.entries.len(),
             crate::sync::state::payload_digest(&plaintext),
         )
     };
@@ -479,7 +483,7 @@ pub async fn sync_remove_device(
             .lock()
             .map_err(|_| "Sesame could not read the unlocked vault.".to_string())?;
         let vault = session.as_mut().ok_or("Unlock Sesame before syncing.")?;
-        let payload = vault.payload.clone();
+        let payload = vault.open_payload()?.clone();
         let recovery_kit = super::sync_adopt::adopt(vault, new_key, payload, &master_password)?;
         state.advance_session_epoch();
         recovery_kit
@@ -580,6 +584,7 @@ pub async fn sync_conflict_details(
         .lock()
         .map_err(|_| "Sesame could not read the unlocked vault.".to_string())?;
     let vault = session.as_ref().ok_or("Unlock Sesame before syncing.")?;
+    let local_payload = vault.open_payload()?;
     let remote = decrypt_snapshot(&vault.key, &envelope)?;
     let remote_payload: crate::vault::types::VaultPayload = serde_json::from_slice(&remote)
         .map_err(|_| "The synced vault could not be read.".to_string())?;
@@ -589,7 +594,7 @@ pub async fn sync_conflict_details(
             device_label: "This device".to_string(),
             revision: base.as_ref().map(|entry| entry.revision).unwrap_or(0),
             changed_at: String::new(),
-            entry_count: vault.payload.entries.len(),
+            entry_count: local_payload.entries.len(),
         },
         other_device: SyncConflictSideView {
             device_label: sender_label,
@@ -645,13 +650,14 @@ pub async fn sync_resolve_conflict(
             .map_err(|_| "Sesame could not read the unlocked vault.".to_string())?;
         let vault = session.as_ref().ok_or("Unlock Sesame before syncing.")?;
 
-        let local = serde_json::to_vec(&vault.payload)
+        let local_payload = vault.open_payload()?;
+        let local = serde_json::to_vec(&*local_payload)
             .map_err(|_| "Sesame could not read the local vault.".to_string())?;
         let remote = decrypt_snapshot(&vault.key, &envelope)?;
         let remote_payload: crate::vault::types::VaultPayload = serde_json::from_slice(&remote)
             .map_err(|_| "The synced vault could not be read.".to_string())?;
         let remote_entries = remote_payload.entries.len();
-        let local_entries = vault.payload.entries.len();
+        let local_entries = local_payload.entries.len();
 
         let directory = crate::sync::conflict_backup::backup_dir(&data_dir);
         let stamp = backup_stamp();
@@ -782,7 +788,8 @@ pub async fn sync_resolve_conflict(
 
 /// Refuses to continue if the local vault changed since capture: the recovery copy lacks later edits.
 fn confirm_unchanged(vault: &crate::vault::UnlockedVault, captured: &str) -> Result<(), String> {
-    let now = serde_json::to_vec(&vault.payload)
+    let payload = vault.open_payload()?;
+    let now = serde_json::to_vec(&*payload)
         .map_err(|_| "Sesame could not read the local vault.".to_string())?;
     if crate::sync::state::payload_digest(&now) != captured {
         return Err(
@@ -890,7 +897,8 @@ async fn run_one_transfer(
             .lock()
             .map_err(|_| "Sesame could not read the unlocked vault.".to_string())?;
         let vault = session.as_ref().ok_or("sync_locked")?;
-        let plaintext = serde_json::to_vec(&vault.payload)
+        let payload = vault.open_payload()?;
+        let plaintext = serde_json::to_vec(&*payload)
             .map_err(|_| "Sesame could not read the local vault.".to_string())?;
         base.as_ref()
             .map(|entry| entry.has_local_changes(&plaintext))

--- a/src-tauri/src/commands/sync_transfer_recovery.rs
+++ b/src-tauri/src/commands/sync_transfer_recovery.rs
@@ -19,7 +19,8 @@ pub async fn sync_restore_conflict_backup(app: AppHandle, state: tauri::State<'_
     let contents = crate::sync::conflict_backup::read_verified(&path, &vault.key)?;
     let payload: crate::vault::types::VaultPayload = serde_json::from_slice(&contents.payload).map_err(|_| "That recovery copy could not be read.".to_string())?;
     let entry_count = payload.entries.len();
-    let current_payload = serde_json::to_vec(&vault.payload).map_err(|_| "Sesame could not read the local vault.".to_string())?;
+    let current = vault.open_payload()?;
+    let current_payload = serde_json::to_vec(&*current).map_err(|_| "Sesame could not read the local vault.".to_string())?;
     let written = crate::sync::conflict_backup::write_verified(&directory, vault, crate::sync::conflict_backup::Side::ThisDevice, contents.revision, &current_payload, &backup_stamp())?;
     crate::vault::storage::commit_payload_change(vault, payload)?;
     state.advance_session_epoch();

--- a/src-tauri/src/commands/trash.rs
+++ b/src-tauri/src/commands/trash.rs
@@ -3,8 +3,7 @@
 
 use tauri::State;
 
-use crate::vault::snapshot::snapshot_for;
-use crate::vault::trash::{restore_item, trash_item_preview};
+use crate::vault::trash::restore_item;
 use crate::vault::types::{ItemPreview, RestoreTrashedItemResult};
 use crate::vault::{VaultResult, VaultState};
 
@@ -20,7 +19,7 @@ pub fn preview_trashed_item(id: String, state: State<'_, VaultState>) -> VaultRe
         .lock()
         .map_err(|_| "Sesame could not read the vault session.".to_string())?;
     let session = session.as_ref().ok_or("Unlock your vault first.")?;
-    trash_item_preview(&session.payload, id)
+    session.trash_item_preview(id)
 }
 
 #[tauri::command]
@@ -39,11 +38,12 @@ pub fn restore_trashed_item(
     let session = session
         .as_mut()
         .ok_or("Unlock your vault before restoring an item.")?;
-    let next_payload = restore_item(&session.payload, id)?;
+    let payload = session.open_payload()?;
+    let next_payload = restore_item(&payload, id)?;
     crate::vault::storage::commit_payload_change(session, next_payload)?;
     state.advance_session_epoch();
     Ok(RestoreTrashedItemResult {
         restored_id: id.to_string(),
-        snapshot: snapshot_for(&session.payload),
+        snapshot: session.snapshot(),
     })
 }


### PR DESCRIPTION
## Scope

- Area: vault core
- Linked issue: none
- Depends on: nothing

## What changed

`UnlockedVault` no longer keeps the whole plaintext payload. Unlock now
seals every record into its own authenticated blob (AEAD bound to role,
id, and kind), keeps a redacted index, and hands out one record at a
time. Snapshot, status, search, quick access, TOTP, duplicate groups,
field suggestions, autotype, trash and history previews, and browser fill
read the index first and open only the records they need. Mutations still
rebuild the payload to persist it, but the store is replaced only after
the write succeeds and the previous plaintext is zeroized.

The on-disk format stays at version 10. Record authentication is
in-memory only, so there is nothing to migrate.

## Security and data boundary

- [x] This does not send vault contents, passwords, TOTP seeds, recovery data, or encryption keys to a Sesame service.
- [x] I reviewed changes to unlock, encryption, backup, import, browser messaging, authentication, or audit behaviour.
- [x] Any new logs and diagnostics are secret-safe.
- [ ] Not applicable; this change does not touch a security or data boundary.

The plaintext payload used to live in the session for the whole unlock,
so any reader saw every secret. Now the session holds sealed blobs plus a
redacted index, plaintext exists only inside an opened record, and opened
values zeroize on drop. Swapped, relabelled, or tampered records fail to
open. The disk format and its AAD labels are untouched, and nothing new
crosses to the renderer: the redacted index was already the wire shape
for snapshots.

## Validation

```text
cargo test --manifest-path src-tauri/sesame-core/Cargo.toml record_store
  11 passed: swapped ciphertexts, relabelled records, wrong keys,
  malformed blobs, rollback after a failed replacement, and secret
  canaries absent from the idle index and previews
npm run desktop:test:rust
  102 vault core tests plus every integration suite pass
npm run desktop:lint:rust
  passes
npm run desktop:ci
  full gate passes, including the production build and the Sync preview
  tests
```

Unlock, persist, and password-rotation round trips are covered by the new
storage tests. I did not run the desktop app by hand; this environment
has no session.

## Evidence

CI run on this branch.

## Review notes

- [x] Generated output and local state are not included.
- [x] Documentation matches the implemented state.
- [x] This change is safe to revert independently, or the dependency is documented above.

sesame-core carries pre-existing rustfmt drift that the lint gate never
sees (`cargo fmt --check` without `--all` covers only the `sesame`
package). This branch passes the gate command with the pinned 1.93.1
toolchain; the drift is left alone.
