### PR TITLE
Release Sesame 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Every released version has a section here. The release workflow reads the
 section matching the tag and puts it at the top of the GitHub release, so a
 release cannot be published without saying what changed in it.
 
-## 0.2.0
+## 0.2.1
 
 - Revealing a saved password now asks for the master password in a proper
   dialog instead of an unstyled inline row. The login editor can also show the
@@ -13,6 +13,9 @@ release cannot be published without saying what changed in it.
 - Copy and reveal prompts no longer stack notifications: opening the master
   password dialog does not also raise a "Nothing to copy" notice, and a wrong
   master password reports its error once, inside the dialog that asked for it.
+
+## 0.2.0
+
 - Sesame now runs on Linux. The same vault, record types, unlock methods,
   auto-lock, quick access, backups, and browser integration work on Linux, and
   the build produces deb, rpm, and AppImage packages. Device protection keeps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sesame",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sesame",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sesame",
   "private": true,
   "license": "AGPL-3.0-or-later",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "desktop:dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "sesame"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arboard",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [".", "sesame-core"]
 
 [package]
 name = "sesame"
-version = "0.2.0"
+version = "0.2.1"
 license = "AGPL-3.0-or-later"
 default-run = "sesame"
 description = "A calm, local-first password and recovery vault"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Sesame",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "app.usesesame.desktop",
   "build": {
     "beforeDevCommand": "npm run desktop:dev",


### PR DESCRIPTION
Cut patch release 0.2.1 for the two post-0.2.0 fixes already merged into main. The release notes cover the presence-gated login editor reveal and the master-password dialog notification cleanup.\n\nValidation: npm run desktop:version:check