### PR TITLE
Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Every released version has a section here. The release workflow reads the
 section matching the tag and puts it at the top of the GitHub release, so a
 release cannot be published without saying what changed in it.
 
+## 0.2.2
+
+- The release chain carries Linux end to end. The desktop app reports its real
+  operating system when it registers with the account service, the updater
+  runs on Linux, and update receipts are verified against the running
+  platform. The release pipeline accepts Linux candidates and writes
+  linux-appimage updater manifest targets, the server ingests them, serves
+  update checks for the asking platform, and answers per-platform
+  latest-release lookups, and the admin release controls and the website's
+  builds page show both channels.
+
 ## 0.2.1
 
 - Revealing a saved password now asks for the master password in a proper

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sesame",
   "private": true,
   "license": "AGPL-3.0-or-later",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "desktop:dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "sesame"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arboard",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [".", "sesame-core"]
 
 [package]
 name = "sesame"
-version = "0.2.1"
+version = "0.2.2"
 license = "AGPL-3.0-or-later"
 default-run = "sesame"
 description = "A calm, local-first password and recovery vault"

--- a/src-tauri/src/adapters/network/account_api.rs
+++ b/src-tauri/src/adapters/network/account_api.rs
@@ -97,7 +97,7 @@ pub async fn get_service_connection_status(app: AppHandle) -> VaultResult<Servic
         .header("Authorization", format!("Sesame {token}"))
         .json(&serde_json::json!({
             "appVersion": env!("CARGO_PKG_VERSION"),
-            "platform": "windows",
+            "platform": std::env::consts::OS,
             "architecture": std::env::consts::ARCH,
             "updateChannel": "beta",
             "protocolVersion": 1,

--- a/src-tauri/src/adapters/platform/capabilities.rs
+++ b/src-tauri/src/adapters/platform/capabilities.rs
@@ -30,7 +30,7 @@ pub fn get_platform_capabilities() -> PlatformCapabilities {
         session_auto_lock: crate::session_guard::idle_auto_lock_available(),
         quick_access_shortcut: crate::desktop_shell::global_shortcut_available(),
         account_linking: cfg!(windows),
-        desktop_updates: cfg!(windows),
+        desktop_updates: cfg!(windows) || cfg!(target_os = "linux"),
         window_controls: cfg!(windows),
     }
 }

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -35,7 +35,7 @@ struct CandidateReceipt {
 }
 
 async fn check(app: &AppHandle) -> VaultResult<Option<VerifiedDesktopUpdate>> {
-    if !cfg!(windows) {
+    if !(cfg!(windows) || cfg!(target_os = "linux")) {
         return Err("Desktop updates are not available on this operating system.".into());
     }
     if option_env!("SESAME_UPDATER_PUBLIC_KEY").is_none_or(|key| key.trim().is_empty()) {
@@ -56,7 +56,7 @@ async fn check(app: &AppHandle) -> VaultResult<Option<VerifiedDesktopUpdate>> {
                 &update.signature,
                 candidate_public_key,
                 candidate_key_id,
-                "windows",
+                updater_platform()?,
                 updater_architecture()?,
             )?;
             Ok(VerifiedDesktopUpdate {
@@ -126,6 +126,14 @@ fn updater_architecture() -> VaultResult<&'static str> {
         "x86_64" => Ok("x86_64"),
         "aarch64" => Ok("aarch64"),
         _ => Err("This architecture is not supported by the Sesame updater.".into()),
+    }
+}
+
+fn updater_platform() -> VaultResult<&'static str> {
+    match std::env::consts::OS {
+        "windows" => Ok("windows"),
+        "linux" => Ok("linux"),
+        _ => Err("This operating system is not supported by the Sesame updater.".into()),
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Sesame",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "app.usesesame.desktop",
   "build": {
     "beforeDevCommand": "npm run desktop:dev",

--- a/tools/create-static-update-manifest.mjs
+++ b/tools/create-static-update-manifest.mjs
@@ -27,8 +27,9 @@ const lineValue = (value) => typeof value === 'string' && value !== '' && !value
 if (
   candidate?.schemaVersion !== 2 || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(candidate.version) ||
   !lineValue(candidate.channel) ||
-  candidate.platform !== 'windows' || !['x86_64', 'aarch64'].includes(candidate.architecture) ||
-  !lineValue(candidate.supportedWindows) || !lineValue(candidate.releaseNotesURL) ||
+  !['windows', 'linux'].includes(candidate.platform) || !['x86_64', 'aarch64'].includes(candidate.architecture) ||
+  (candidate.platform === 'windows' ? !lineValue(candidate.supportedWindows) : candidate.supportedWindows !== '') ||
+  !lineValue(candidate.releaseNotesURL) ||
   !lineValue(artifact?.objectKey) || !lineValue(artifact?.updaterSignature) ||
   artifact.updaterSignature.length < 64 || !/^[0-9a-f]{64}$/.test(artifact.sha256) ||
   !Number.isSafeInteger(artifact.bytes) || artifact.bytes <= 0 ||
@@ -42,7 +43,7 @@ if (
   !lineValue(candidate.candidateSigningKeyId) || !lineValue(candidate.candidateSignature) ||
   Buffer.from(candidate.candidateSignature, 'base64url').length !== 64
 ) {
-  throw new Error('The candidate is not a complete schema-v2 Windows updater record.')
+  throw new Error('The candidate is not a complete schema-v2 desktop updater record.')
 }
 try {
   const releaseNotes = new URL(candidate.releaseNotesURL)
@@ -97,7 +98,7 @@ if (candidatePublicKey) {
   }
 }
 
-const target = `windows-${candidate.architecture}-nsis`
+const target = candidate.platform === 'linux' ? `linux-${candidate.architecture}-appimage` : `windows-${candidate.architecture}-nsis`
 const manifest = {
   version: candidate.version,
   notes: `Verification and release notes: ${candidate.releaseNotesURL}`,

--- a/tools/create-static-update-manifest.test.mjs
+++ b/tools/create-static-update-manifest.test.mjs
@@ -10,7 +10,7 @@ import test from 'node:test'
 const run = promisify(execFile)
 const script = resolve('tools/create-static-update-manifest.mjs')
 
-function fictionalCandidate() {
+function fictionalCandidate(overrides = {}) {
   const candidate = {
     schemaVersion: 2,
     version: '1.2.3',
@@ -40,6 +40,9 @@ function fictionalCandidate() {
     candidateSigningKeyId: 'candidate-1',
     candidateSignature: '',
   }
+  const { artifact: artifactOverrides, ...candidateOverrides } = overrides
+  Object.assign(candidate, candidateOverrides)
+  if (artifactOverrides) candidate.artifact = { ...candidate.artifact, ...artifactOverrides }
   const stableJSON = (value) => {
     if (value === null || typeof value !== 'object') return JSON.stringify(value)
     if (Array.isArray(value)) return `[${value.map(stableJSON).join(',')}]`
@@ -54,7 +57,7 @@ function fictionalCandidate() {
     artifact.distributionClass, String(artifact.sigstoreVerified), artifact.sigstoreIssuer,
     artifact.sigstoreIdentity, artifact.sigstoreBundleSha256, digest(artifact.sigstoreEvidence),
     String(artifact.authenticodeVerified), artifact.authenticodeSubject,
-    artifact.authenticodeThumbprint, digest(artifact.authenticodeEvidence),
+    artifact.authenticodeThumbprint, artifact.authenticodeEvidence ? digest(artifact.authenticodeEvidence) : '',
   ].join('\n')
   const { privateKey, publicKey } = generateKeyPairSync('ed25519')
   candidate.candidateSignature = sign(null, Buffer.from(payload), privateKey).toString('base64url')
@@ -84,6 +87,44 @@ test('static updater manifest carries the public artifact and exact signed recei
     assert.equal(manifest.candidateReceipt.payload.split('\n').length, 23)
     assert.equal(manifest.candidateReceipt.payload.split('\n')[9], 'a'.repeat(64))
     assert.equal(manifest.candidateReceipt.payload.split('\n')[7], 'https://releases.example.test/v1.2.3/Sesame_1.2.3_x64-setup.exe')
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('static updater manifest carries Linux AppImage targets without Windows fields', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'sesame-update-manifest-'))
+  try {
+    const candidatePath = join(directory, 'candidate.json')
+    const outputPath = join(directory, 'latest.json')
+    const { candidate, candidatePublicKey } = fictionalCandidate({
+      channel: 'beta',
+      platform: 'linux',
+      supportedWindows: '',
+      artifact: {
+        url: 'https://releases.example.test/v1.2.3/Sesame_1.2.3_amd64.AppImage',
+        objectKey: 'linux/v1.2.3/Sesame_1.2.3_amd64.AppImage',
+        distributionClass: 'early_access',
+        authenticodeVerified: false,
+        authenticodeSubject: undefined,
+        authenticodeThumbprint: undefined,
+        authenticodeEvidence: undefined,
+      },
+    })
+    await writeFile(candidatePath, JSON.stringify(candidate))
+    await run(process.execPath, [script, candidatePath, outputPath], {
+      env: {
+        ...process.env,
+        SESAME_PUBLIC_UPDATE_ARTIFACT_URL: 'https://github.com/usesesame/sesame-desktop/releases/download/v1.2.3/Sesame_1.2.3_amd64.AppImage',
+        SESAME_RELEASE_CANDIDATE_PUBLIC_KEY: candidatePublicKey,
+      },
+    })
+    const manifest = JSON.parse(await readFile(outputPath, 'utf8'))
+    assert.equal(manifest.version, '1.2.3')
+    assert.deepEqual(Object.keys(manifest.platforms), ['linux-x86_64-appimage'])
+    const claims = manifest.candidateReceipt.payload.split('\n')
+    assert.equal(claims[3], 'linux')
+    assert.equal(claims[5], '')
   } finally {
     await rm(directory, { recursive: true, force: true })
   }


### PR DESCRIPTION
Carries Linux through the desktop release chain: the app reports its real platform, the updater runs on Linux, the static manifest tool emits linux-appimage targets with a contract test, and the version prepares 0.2.2. Checks: version contract, desktop contracts (60), lint, svelte-check, clippy, fmt, and the Rust suite all pass.