### PR TITLE
Prepare the 0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Every released version has a section here. The release workflow reads the
 section matching the tag and puts it at the top of the GitHub release, so a
 release cannot be published without saying what changed in it.
 
+## 0.2.3
+
+- Restoring a backup from an older Sesame release now upgrades it to the current
+  format instead of installing it as it was written. Backups written by 0.1.0
+  through 0.2.2 are covered, and the selected backup file is never modified.
+- Restore makes a safety copy of your current vault and only replaces it at the
+  last step. If any step fails, your vault and the backup are left as they were.
+- Restore errors now say what went wrong: a wrong master password, a damaged
+  file, or a vault that needs a newer Sesame.
+
 ## 0.2.2
 
 - The release chain carries Linux end to end. The desktop app reports its real

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sesame",
   "private": true,
   "license": "AGPL-3.0-or-later",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "desktop:dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "sesame"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "arboard",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ glib = { path = "vendor/glib" }
 
 [package]
 name = "sesame"
-version = "0.2.2"
+version = "0.2.3"
 license = "AGPL-3.0-or-later"
 default-run = "sesame"
 description = "A calm, local-first password and recovery vault"

--- a/src-tauri/sesame-core/src/api.rs
+++ b/src-tauri/sesame-core/src/api.rs
@@ -2,12 +2,9 @@
 
 use zeroize::{Zeroize, Zeroizing};
 
-use crate::backup::unwrap_vault_key;
-use crate::crypto::{
-    decrypt_bytes, default_kdf_params, derive_key, encrypt_bytes, serialize_payload,
-};
-use crate::migration::{fresh_vault_id, migrate_payload, migrate_vault_file};
-use crate::storage::check_supported_vault_format;
+use crate::crypto::{default_kdf_params, derive_key, encrypt_bytes, serialize_payload};
+use crate::loader::{Credential, MigrationPlan, VaultLoader};
+use crate::migration::fresh_vault_id;
 use crate::types::{Folder, VaultEntry, VaultFile, VaultPayload};
 use crate::util::{fill_random, generate_recovery_kit};
 use crate::{
@@ -22,6 +19,7 @@ pub struct OpenedVault {
     pub file: VaultFile,
     /// True when opening upgraded file/payload in memory; the caller decides when to persist.
     pub migrated: bool,
+    pub migration: MigrationPlan,
 }
 
 impl Drop for OpenedVault {
@@ -30,102 +28,41 @@ impl Drop for OpenedVault {
     }
 }
 
-/// Rejects a format this version cannot safely open, before any key derivation.
 pub fn parse_vault_file(bytes: &[u8]) -> VaultResult<VaultFile> {
-    let file: VaultFile = serde_json::from_slice(bytes).map_err(|_| {
-        "This vault file is not valid. Restore a known-good encrypted backup.".to_string()
-    })?;
-    check_supported_vault_format(&file)?;
-    Ok(file)
+    VaultLoader::parse(bytes).map_err(Into::into)
 }
 
-/// Either secret unlocks; the desktop commands stay strictly single-secret-type.
 pub fn open_vault(file: &VaultFile, secret: &str) -> VaultResult<OpenedVault> {
-    let key = unwrap_vault_key(file, secret)?;
-    open_vault_with_key(file, key_array_from(key.as_slice())?)
+    VaultLoader::open(file, Credential::PasswordOrRecoveryKit(secret)).map_err(Into::into)
 }
 
-/// Master password only; never falls back to treating the input as a recovery kit.
 pub fn open_vault_with_password(file: &VaultFile, password: &str) -> VaultResult<OpenedVault> {
-    open_vault_with_key(file, unwrap_key_with_password(file, password)?)
+    VaultLoader::open(file, Credential::MasterPassword(password)).map_err(Into::into)
 }
 
-/// Recovery kit only; the format-2 fallback applies only to a genuinely legacy stored format.
-pub fn open_vault_with_recovery_kit(
-    file: &VaultFile,
-    recovery_kit: &str,
-) -> VaultResult<OpenedVault> {
-    open_vault_with_key(file, unwrap_key_with_recovery_kit(file, recovery_kit)?)
+pub fn open_vault_with_recovery_kit(file: &VaultFile, kit: &str) -> VaultResult<OpenedVault> {
+    VaultLoader::open(file, Credential::RecoveryKit(kit)).map_err(Into::into)
 }
 
-/// Unwraps the key without decrypting the payload; avoids a double decrypt in full-open callers.
 pub fn unwrap_key_with_password(file: &VaultFile, password: &str) -> VaultResult<[u8; 32]> {
-    let wrapping_key = Zeroizing::new(derive_key(password, &file.kdf)?);
-    let key = Zeroizing::new(
-        decrypt_bytes(&wrapping_key, &file.key_wrap, WRAP_AAD).map_err(|_| {
-            "Sesame could not unlock this vault. Check your master password.".to_string()
-        })?,
-    );
-    key_array_from(key.as_slice())
+    VaultLoader::unwrap_key(file, Credential::MasterPassword(password))
+        .map(|key| *key)
+        .map_err(Into::into)
 }
 
-pub fn unwrap_key_with_recovery_kit(file: &VaultFile, recovery_kit: &str) -> VaultResult<[u8; 32]> {
-    let normalized_kit = recovery_kit.trim().to_ascii_uppercase();
-    let (recovery_kdf, recovery_wrap, aad) = match (&file.recovery_kdf, &file.recovery_wrap) {
-        (Some(recovery_kdf), Some(recovery_wrap)) => {
-            (recovery_kdf, recovery_wrap, RECOVERY_WRAP_AAD)
-        }
-        // Fallback only for a genuinely legacy envelope; a stripped current-format file must say so.
-        _ if file.format_version < VAULT_FORMAT_VERSION => {
-            (&file.kdf, &file.key_wrap, WRAP_AAD)
-        }
-        _ => {
-            return Err(
-                "This vault file has no recovery wrapper. It has been changed or damaged since Sesame wrote it. Restore a known-good encrypted backup."
-                    .into(),
-            )
-        }
-    };
-    let wrapping_key = Zeroizing::new(derive_key(&normalized_kit, recovery_kdf)?);
-    let key = Zeroizing::new(
-        decrypt_bytes(&wrapping_key, recovery_wrap, aad)
-            .map_err(|_| "That recovery kit is not correct.".to_string())?,
-    );
-    key_array_from(key.as_slice())
+pub fn unwrap_key_with_recovery_kit(file: &VaultFile, kit: &str) -> VaultResult<[u8; 32]> {
+    VaultLoader::unwrap_key(file, Credential::RecoveryKit(kit))
+        .map(|key| *key)
+        .map_err(Into::into)
 }
 
-fn key_array_from(key: &[u8]) -> VaultResult<[u8; 32]> {
-    key.try_into().map_err(|_| {
-        "The local vault key is invalid. Restore a known-good encrypted backup.".to_string()
-    })
-}
-
-/// For keys already known by some other means, such as a PIN or Hello wrap.
 pub fn open_vault_with_key(file: &VaultFile, key: [u8; 32]) -> VaultResult<OpenedVault> {
-    let mut file = file.clone();
-    let stored_payload_aad = payload_aad_for_file(file.format_version, file.setup_complete)?;
-    let file_migrated = migrate_vault_file(&mut file)?;
-    let payload_bytes = Zeroizing::new(
-        decrypt_bytes(&key, &file.payload, stored_payload_aad).map_err(|_| {
-            "The vault data could not be authenticated. Restore a known-good encrypted backup."
-                .to_string()
-        })?,
-    );
-    let mut payload: VaultPayload =
-        serde_json::from_slice(payload_bytes.as_slice()).map_err(|_| {
-            "The vault data could not be read. Restore a known-good encrypted backup.".to_string()
-        })?;
-    let payload_migrated = migrate_payload(&mut payload);
-    Ok(OpenedVault {
-        key: Zeroizing::new(key),
-        payload,
-        file,
-        migrated: file_migrated || payload_migrated,
-    })
+    let key = Zeroizing::new(key);
+    VaultLoader::open(file, Credential::VaultKey(&key)).map_err(Into::into)
 }
 
 pub fn open_vault_bytes(bytes: &[u8], secret: &str) -> VaultResult<OpenedVault> {
-    open_vault(&parse_vault_file(bytes)?, secret)
+    VaultLoader::load(bytes, Credential::PasswordOrRecoveryKit(secret)).map_err(Into::into)
 }
 
 /// Fresh vault; the recovery kit returns in plain text exactly once.
@@ -169,6 +106,12 @@ pub fn create_vault(password: &str, vault_name: &str) -> VaultResult<(OpenedVaul
             payload,
             file,
             migrated: false,
+            migration: MigrationPlan {
+                source_format: VAULT_FORMAT_VERSION,
+                target_format: VAULT_FORMAT_VERSION,
+                envelope_changed: false,
+                payload_changed: false,
+            },
         },
         recovery_kit_for_display,
     ))

--- a/src-tauri/sesame-core/src/backup.rs
+++ b/src-tauri/sesame-core/src/backup.rs
@@ -9,7 +9,8 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::crypto::{encrypt_bytes, serialize_payload};
 use crate::loader::{Credential, VaultLoader};
 use crate::platform::{
-    copy_private_file, create_private_dir, open_private_file, replace_file, unprotect_for_device,
+    copy_private_file, create_private_dir, open_private_file, replace_file, same_file_identity,
+    unprotect_for_device,
 };
 use crate::{
     types::*,
@@ -480,43 +481,13 @@ fn same_file(source: &Path, destination: &Path) -> bool {
     if source == destination {
         return true;
     }
-    let same_metadata = match (fs::metadata(source), fs::metadata(destination)) {
-        (Ok(source), Ok(destination)) => same_file_metadata(&source, &destination),
-        _ => false,
-    };
-    if same_metadata {
+    if same_file_identity(source, destination) {
         return true;
     }
     match (fs::canonicalize(source), fs::canonicalize(destination)) {
         (Ok(source), Ok(destination)) => source == destination,
         _ => false,
     }
-}
-
-#[cfg(unix)]
-fn same_file_metadata(source: &fs::Metadata, destination: &fs::Metadata) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    source.dev() == destination.dev() && source.ino() == destination.ino()
-}
-
-#[cfg(windows)]
-fn same_file_metadata(source: &fs::Metadata, destination: &fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt;
-    match (
-        (source.volume_serial_number(), source.file_index()),
-        (destination.volume_serial_number(), destination.file_index()),
-    ) {
-        (
-            (Some(source_volume), Some(source_index)),
-            (Some(destination_volume), Some(destination_index)),
-        ) => source_volume == destination_volume && source_index == destination_index,
-        _ => false,
-    }
-}
-
-#[cfg(not(any(unix, windows)))]
-fn same_file_metadata(_source: &fs::Metadata, _destination: &fs::Metadata) -> bool {
-    false
 }
 
 fn validate_migrated_payload(payload: &VaultPayload, source_format: u8) -> VaultResult<()> {

--- a/src-tauri/sesame-core/src/backup.rs
+++ b/src-tauri/sesame-core/src/backup.rs
@@ -1,12 +1,16 @@
+use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use zeroize::{Zeroize, Zeroizing};
 
+use crate::crypto::{encrypt_bytes, serialize_payload};
 use crate::loader::{Credential, VaultLoader};
-use crate::platform::unprotect_for_device;
-use crate::storage::write_vault_file;
+use crate::platform::{
+    copy_private_file, create_private_dir, open_private_file, replace_file, unprotect_for_device,
+};
 use crate::{
     types::*,
     util::{random_id, unix_timestamp},
@@ -283,82 +287,408 @@ pub fn snapshot_vault_revision(vault: &Path, label: &str) -> VaultResult<Option<
     Ok(Some(name))
 }
 
-/// Authenticates before anything is invalidated: a failure must never lock the user out.
+pub struct PreparedRestore {
+    file: VaultFile,
+    key: Zeroizing<[u8; 32]>,
+}
+
+pub struct RestoreInstall {
+    pub safety_backup_name: Option<String>,
+    pub pin_unlock_available: bool,
+    pub hello_unlock_available: bool,
+}
+
 pub fn prepare_backup_for_restore(
     source: &Path,
     destination: &Path,
     secret: &str,
-) -> VaultResult<VaultFile> {
-    let mut file = read_backup_file(source)?;
-    if source == destination {
+) -> VaultResult<PreparedRestore> {
+    if same_file(source, destination) {
         return Err("Choose an exported backup, not Sesame's active vault file.".into());
     }
 
-    // Prove genuine and openable before anything replaces the working vault.
-    authenticate_vault_file(&file, secret)?;
-    // Drop unlock material a Windows profile cannot open, so a cross-profile restore offers no doomed PIN.
+    let source_file = read_backup_file(source)?;
+    let opened = VaultLoader::open(&source_file, Credential::PasswordOrRecoveryKit(secret))
+        .map_err(|error| match error {
+            crate::loader::LoadFailure::RecoveryRequired { format } => migration_error(
+                format,
+                "its authenticated records need the recovery reader.",
+            ),
+            error => error.to_string(),
+        })?;
+    validate_migrated_payload(&opened.payload, opened.migration.source_format)?;
+    let mut file = opened.file.clone();
+    if file.setup_complete && (file.recovery_kdf.is_none() || file.recovery_wrap.is_none()) {
+        return Err(migration_error(
+            opened.migration.source_format,
+            "its recovery access is incomplete.",
+        ));
+    }
     strip_unusable_device_material(&mut file);
-    Ok(file)
+    let payload = Zeroizing::new(serialize_payload(&opened.payload).map_err(|_| {
+        migration_error(
+            opened.migration.source_format,
+            "its migrated records could not be encoded.",
+        )
+    })?);
+    let aad =
+        crate::payload_aad_for_file(file.format_version, file.setup_complete).map_err(|_| {
+            migration_error(
+                opened.migration.source_format,
+                "its current authentication label is invalid.",
+            )
+        })?;
+    file.payload = encrypt_bytes(&opened.key, &payload, aad).map_err(|_| {
+        migration_error(
+            opened.migration.source_format,
+            "its migrated records could not be resealed.",
+        )
+    })?;
+    let sealed = Zeroizing::new(serde_json::to_vec(&file).map_err(|_| {
+        migration_error(
+            opened.migration.source_format,
+            "the upgraded vault file could not be encoded.",
+        )
+    })?);
+    let reopened =
+        VaultLoader::load(&sealed, Credential::PasswordOrRecoveryKit(secret)).map_err(|_| {
+            migration_error(
+                opened.migration.source_format,
+                "the resealed vault did not authenticate.",
+            )
+        })?;
+    let reopened_payload = Zeroizing::new(serialize_payload(&reopened.payload).map_err(|_| {
+        migration_error(
+            opened.migration.source_format,
+            "the resealed records could not be checked.",
+        )
+    })?);
+    if reopened.migration.required() || *payload != *reopened_payload {
+        return Err(migration_error(
+            opened.migration.source_format,
+            "the upgraded records changed during validation.",
+        ));
+    }
+    Ok(PreparedRestore {
+        file,
+        key: Zeroizing::new(*opened.key),
+    })
 }
 
-/// Caller must hold the lifecycle guard so no concurrent save resurrects the old vault.
-#[allow(clippy::type_complexity)]
 pub fn apply_restored_vault_file(
     destination: &Path,
-    file: &VaultFile,
-) -> VaultResult<(Option<String>, bool, bool)> {
-    apply_restored_vault_file_with_writer(destination, file, write_vault_file)
+    prepared: &PreparedRestore,
+) -> VaultResult<RestoreInstall> {
+    apply_restored_vault_file_with_storage(destination, prepared, &mut FileRestoreStorage)
 }
 
-/// Write closure for fault injection after the safety copy exists.
-#[allow(clippy::type_complexity)]
-pub fn apply_restored_vault_file_with_writer<F>(
+fn apply_restored_vault_file_with_storage<S: RestoreStorage>(
     destination: &Path,
-    file: &VaultFile,
-    write_file: F,
-) -> VaultResult<(Option<String>, bool, bool)>
-where
-    F: FnOnce(&Path, &VaultFile) -> VaultResult<()>,
-{
-    let safety_backup_name = if destination.exists() {
+    prepared: &PreparedRestore,
+    storage: &mut S,
+) -> VaultResult<RestoreInstall> {
+    let safety_backup_name = if storage.exists(destination) {
         let backup_dir = destination
             .parent()
-            .ok_or("Sesame could not find the vault folder.")?
+            .ok_or("Sesame could not find the vault folder. Restart Sesame and try again.")?
             .join("backups");
-        fs::create_dir_all(&backup_dir)
-            .map_err(|_| "Sesame could not prepare a pre-restore backup.".to_string())?;
+        storage.create_dir(&backup_dir).map_err(|_| {
+            "Sesame could not prepare the safety-backup folder. Check local storage and try again."
+                .to_string()
+        })?;
         let name = format!(
             "sesame-before-restore-{}-{}.sesame",
             unix_timestamp(),
             random_id()
         );
-        fs::copy(destination, backup_dir.join(&name))
-            .map_err(|_| "Sesame could not create the required pre-restore backup.".to_string())?;
+        let safety = backup_dir.join(&name);
+        if let Err(error) = storage.copy_safety(destination, &safety).and_then(|()| {
+            let active = storage.read(destination)?;
+            let copied = storage.read(&safety)?;
+            if active.as_slice() == copied.as_slice() {
+                Ok(())
+            } else {
+                Err("Sesame could not verify the safety backup. The active vault was not changed. Check local storage and try again.".to_string())
+            }
+        }) {
+            storage.remove(&safety);
+            return Err(error);
+        }
         Some(name)
     } else {
         None
     };
 
-    let pin_unlock_available = file.pin_wrap.is_some();
-    // A Hello wrap whose KSP key does not exist here is caught at unlock, not hidden here.
-    let hello_unlock_available = file.hello_wrap.is_some();
-    write_file(destination, file)?;
-    Ok((
+    let bytes = Zeroizing::new(serde_json::to_vec(&prepared.file).map_err(|_| {
+        "Sesame could not prepare the restored vault. Keep the original backup and try again."
+            .to_string()
+    })?);
+    let parent = destination
+        .parent()
+        .ok_or("Sesame could not find the vault folder. Restart Sesame and try again.")?;
+    storage.create_dir(parent).map_err(|_| {
+        "Sesame could not prepare the vault folder. Check local storage and try again.".to_string()
+    })?;
+    let name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or("Sesame could not read the local vault file name. Restart Sesame and try again.")?;
+    let temporary = parent.join(format!(".{name}.{}.restore.tmp", random_id()));
+    let staged = storage
+        .write_temporary(&temporary, &bytes)
+        .and_then(|()| storage.sync_temporary(&temporary))
+        .and_then(|()| {
+            let stored = storage.read(&temporary)?;
+            if stored.as_slice() != bytes.as_slice() {
+                return Err("Sesame could not verify the restored vault write. The active vault was not changed. Check local storage and try again.".to_string());
+            }
+            let reopened = VaultLoader::load(&stored, Credential::VaultKey(&prepared.key))?;
+            if reopened.migration.required() {
+                return Err("Sesame could not validate the restored vault write. The active vault was not changed. Keep the original backup and try again.".to_string());
+            }
+            Ok(())
+        });
+    if let Err(error) = staged {
+        storage.remove(&temporary);
+        return Err(error);
+    }
+    if let Err(error) = storage.replace(&temporary, destination) {
+        storage.remove(&temporary);
+        return Err(error);
+    }
+
+    let pin_unlock_available = prepared.file.pin_wrap.is_some();
+    let hello_unlock_available = prepared.file.hello_wrap.is_some();
+    Ok(RestoreInstall {
         safety_backup_name,
         pin_unlock_available,
         hello_unlock_available,
-    ))
+    })
 }
 
 /// Single-step authenticate-and-apply; the restore command splits the phases itself.
-#[allow(clippy::type_complexity)]
 pub fn restore_backup_to(
     source: &Path,
     destination: &Path,
     secret: &str,
-) -> VaultResult<(Option<String>, bool, bool)> {
-    let file = prepare_backup_for_restore(source, destination, secret)?;
-    apply_restored_vault_file(destination, &file)
+) -> VaultResult<RestoreInstall> {
+    let prepared = prepare_backup_for_restore(source, destination, secret)?;
+    apply_restored_vault_file(destination, &prepared)
+}
+
+fn same_file(source: &Path, destination: &Path) -> bool {
+    if source == destination {
+        return true;
+    }
+    let same_metadata = match (fs::metadata(source), fs::metadata(destination)) {
+        (Ok(source), Ok(destination)) => same_file_metadata(&source, &destination),
+        _ => false,
+    };
+    if same_metadata {
+        return true;
+    }
+    match (fs::canonicalize(source), fs::canonicalize(destination)) {
+        (Ok(source), Ok(destination)) => source == destination,
+        _ => false,
+    }
+}
+
+#[cfg(unix)]
+fn same_file_metadata(source: &fs::Metadata, destination: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    source.dev() == destination.dev() && source.ino() == destination.ino()
+}
+
+#[cfg(windows)]
+fn same_file_metadata(source: &fs::Metadata, destination: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    match (
+        (source.volume_serial_number(), source.file_index()),
+        (destination.volume_serial_number(), destination.file_index()),
+    ) {
+        (
+            (Some(source_volume), Some(source_index)),
+            (Some(destination_volume), Some(destination_index)),
+        ) => source_volume == destination_volume && source_index == destination_index,
+        _ => false,
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_file_metadata(_source: &fs::Metadata, _destination: &fs::Metadata) -> bool {
+    false
+}
+
+fn validate_migrated_payload(payload: &VaultPayload, source_format: u8) -> VaultResult<()> {
+    if payload
+        .vault_id
+        .as_deref()
+        .is_none_or(|id| id.trim().is_empty())
+        || payload.revision == 0
+    {
+        return Err(migration_error(
+            source_format,
+            "its vault identity or revision is invalid.",
+        ));
+    }
+    let mut folder_ids = HashSet::new();
+    let mut folder_names = HashSet::new();
+    for folder in &payload.folders {
+        if folder.id.trim().is_empty()
+            || folder.name.trim().is_empty()
+            || !folder_ids.insert(folder.id.as_str())
+            || !folder_names.insert(folder.name.to_ascii_lowercase())
+        {
+            return Err(migration_error(source_format, "its folders are invalid."));
+        }
+    }
+    let mut item_ids = HashSet::new();
+    for item in payload.item_views() {
+        if item.id().trim().is_empty()
+            || item_revision(&item) == 0
+            || !item_ids.insert(item.id().to_string())
+        {
+            return Err(migration_error(
+                source_format,
+                "its item identifiers are invalid.",
+            ));
+        }
+        if item
+            .metadata()
+            .item_folder_id()
+            .is_some_and(|folder_id| !folder_ids.contains(folder_id))
+        {
+            return Err(migration_error(
+                source_format,
+                "an item refers to a missing folder.",
+            ));
+        }
+    }
+    let mut history_ids = HashSet::new();
+    for entry in &payload.history {
+        if entry.id.trim().is_empty()
+            || entry.item.id().trim().is_empty()
+            || item_revision(&entry.item) == 0
+            || entry.captured_at == 0
+            || entry
+                .item
+                .metadata()
+                .item_folder_id()
+                .is_some_and(str::is_empty)
+            || !history_ids.insert(entry.id.as_str())
+        {
+            return Err(migration_error(
+                source_format,
+                "its history identifiers are invalid.",
+            ));
+        }
+    }
+    let mut trash_ids = HashSet::new();
+    for entry in &payload.trash {
+        let id = entry.item.id();
+        if id.trim().is_empty()
+            || item_revision(&entry.item) == 0
+            || entry.deleted_at == 0
+            || entry
+                .item
+                .metadata()
+                .item_folder_id()
+                .is_some_and(str::is_empty)
+            || item_ids.contains(id)
+            || !trash_ids.insert(id)
+        {
+            return Err(migration_error(
+                source_format,
+                "its trash identifiers are invalid.",
+            ));
+        }
+    }
+    serialize_payload(payload)
+        .map(|_| ())
+        .map_err(|_| migration_error(source_format, "its records could not be encoded."))
+}
+
+fn item_revision(item: &TaggedItem) -> u32 {
+    match item {
+        TaggedItem::Login(item) => item.revision,
+        TaggedItem::Identity(item) => item.revision,
+        TaggedItem::SecureNote(item) => item.revision,
+        TaggedItem::Card(item) => item.revision,
+        TaggedItem::WifiNetwork(item) => item.revision,
+        TaggedItem::SshKey(item) => item.revision,
+        TaggedItem::SoftwareLicense(item) => item.revision,
+        TaggedItem::Document(item) => item.revision,
+        TaggedItem::CustomRecord(item) => item.revision,
+    }
+}
+
+fn migration_error(source_format: u8, reason: &str) -> String {
+    format!(
+        "Sesame authenticated vault format {source_format}, but could not upgrade it because {reason} Keep the original backup and contact support."
+    )
+}
+
+trait RestoreStorage {
+    fn exists(&self, path: &Path) -> bool;
+    fn create_dir(&mut self, path: &Path) -> VaultResult<()>;
+    fn copy_safety(&mut self, source: &Path, destination: &Path) -> VaultResult<()>;
+    fn read(&mut self, path: &Path) -> VaultResult<Zeroizing<Vec<u8>>>;
+    fn write_temporary(&mut self, path: &Path, bytes: &[u8]) -> VaultResult<()>;
+    fn sync_temporary(&mut self, path: &Path) -> VaultResult<()>;
+    fn replace(&mut self, source: &Path, destination: &Path) -> VaultResult<()>;
+    fn remove(&mut self, path: &Path);
+}
+
+struct FileRestoreStorage;
+
+impl RestoreStorage for FileRestoreStorage {
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn create_dir(&mut self, path: &Path) -> VaultResult<()> {
+        create_private_dir(path)
+    }
+
+    fn copy_safety(&mut self, source: &Path, destination: &Path) -> VaultResult<()> {
+        copy_private_file(source, destination)
+            .map_err(|_| "Sesame could not create the safety backup. The active vault was not changed. Check available disk space and try again.".to_string())
+    }
+
+    fn read(&mut self, path: &Path) -> VaultResult<Zeroizing<Vec<u8>>> {
+        VaultLoader::read_bytes(path).map_err(|_| {
+            "Sesame could not verify the restored vault file. Check local storage and try again."
+                .to_string()
+        })
+    }
+
+    fn write_temporary(&mut self, path: &Path, bytes: &[u8]) -> VaultResult<()> {
+        let mut file = open_private_file(path).map_err(|_| {
+            "Sesame could not prepare the restored vault file. The active vault was not changed. Check local storage and try again."
+                .to_string()
+        })?;
+        file.write_all(bytes)
+            .map_err(|_| "Sesame could not write the restored vault. The active vault was not changed. Check available disk space and try again.".to_string())
+    }
+
+    fn sync_temporary(&mut self, path: &Path) -> VaultResult<()> {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .and_then(|file| file.sync_all())
+            .map_err(|_| "Sesame could not sync the restored vault. The active vault was not changed. Check local storage and try again.".to_string())
+    }
+
+    fn replace(&mut self, source: &Path, destination: &Path) -> VaultResult<()> {
+        replace_file(source, destination).map_err(|_| {
+            "Sesame could not replace the active vault. The active vault was not changed. Check local storage and try again."
+                .to_string()
+        })
+    }
+
+    fn remove(&mut self, path: &Path) {
+        let _ = fs::remove_file(path);
+    }
 }
 
 pub fn read_backup_file(path: &Path) -> VaultResult<VaultFile> {
@@ -370,4 +700,353 @@ pub fn read_backup_file(path: &Path) -> VaultResult<VaultFile> {
 
 pub fn validate_backup_file(file: &VaultFile) -> VaultResult<()> {
     VaultLoader::validate(file).map_err(Into::into)
+}
+
+#[cfg(test)]
+mod restore_fault_tests {
+    use super::*;
+    use crate::{UnlockedVault, VaultState};
+
+    const PASSWORD: &str = "fictional master password 01";
+    const RECOVERY_KIT: &str = "QCSZU-SRJ6G-WP527-YRKXJ-GBS8A";
+    const SOURCE: &[u8] = include_bytes!("../tests/fixtures/compatibility/v0.1.0.sesame");
+    const ACTIVE: &[u8] = include_bytes!("../tests/fixtures/compatibility/v0.2.2.sesame");
+
+    #[derive(Clone, Copy)]
+    enum Fault {
+        SafetyInterrupted,
+        SafetyNoSpace,
+        SafetyCorrupt,
+        TemporaryInterrupted,
+        TemporaryNoSpace,
+        TemporarySync,
+        Replacement,
+    }
+
+    struct FaultStorage {
+        filesystem: FileRestoreStorage,
+        fault: Fault,
+    }
+
+    impl RestoreStorage for FaultStorage {
+        fn exists(&self, path: &Path) -> bool {
+            self.filesystem.exists(path)
+        }
+
+        fn create_dir(&mut self, path: &Path) -> VaultResult<()> {
+            self.filesystem.create_dir(path)
+        }
+
+        fn copy_safety(&mut self, source: &Path, destination: &Path) -> VaultResult<()> {
+            match self.fault {
+                Fault::SafetyInterrupted => {
+                    fs::write(destination, &ACTIVE[..ACTIVE.len() / 2])
+                        .map_err(|_| "fault setup failed".to_string())?;
+                    Err("interrupted safety copy".into())
+                }
+                Fault::SafetyNoSpace => Err("low disk space during safety copy".into()),
+                Fault::SafetyCorrupt => {
+                    self.filesystem.copy_safety(source, destination)?;
+                    fs::write(destination, b"corrupt safety copy")
+                        .map_err(|_| "fault setup failed".to_string())
+                }
+                _ => self.filesystem.copy_safety(source, destination),
+            }
+        }
+
+        fn read(&mut self, path: &Path) -> VaultResult<Zeroizing<Vec<u8>>> {
+            self.filesystem.read(path)
+        }
+
+        fn write_temporary(&mut self, path: &Path, bytes: &[u8]) -> VaultResult<()> {
+            match self.fault {
+                Fault::TemporaryInterrupted => {
+                    fs::write(path, &bytes[..bytes.len() / 2])
+                        .map_err(|_| "fault setup failed".to_string())?;
+                    Err("interrupted temporary write".into())
+                }
+                Fault::TemporaryNoSpace => Err("low disk space during temporary write".into()),
+                _ => self.filesystem.write_temporary(path, bytes),
+            }
+        }
+
+        fn sync_temporary(&mut self, path: &Path) -> VaultResult<()> {
+            if matches!(self.fault, Fault::TemporarySync) {
+                Err("interrupted temporary sync".into())
+            } else {
+                self.filesystem.sync_temporary(path)
+            }
+        }
+
+        fn replace(&mut self, source: &Path, destination: &Path) -> VaultResult<()> {
+            if matches!(self.fault, Fault::Replacement) {
+                Err("replacement failed".into())
+            } else {
+                self.filesystem.replace(source, destination)
+            }
+        }
+
+        fn remove(&mut self, path: &Path) {
+            self.filesystem.remove(path);
+        }
+    }
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!("sesame-restore-{}", random_id()));
+            fs::create_dir(&path).expect("test directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn every_failed_write_phase_preserves_the_source_and_active_vault() {
+        let directory = TestDirectory::new();
+        let source = directory.0.join("source.sesame");
+        let destination = directory.0.join("active.sesame");
+        fs::write(&source, SOURCE).expect("source");
+        fs::write(&destination, ACTIVE).expect("active");
+        let prepared =
+            prepare_backup_for_restore(&source, &destination, PASSWORD).expect("prepared restore");
+
+        for fault in [
+            Fault::SafetyInterrupted,
+            Fault::SafetyNoSpace,
+            Fault::SafetyCorrupt,
+            Fault::TemporaryInterrupted,
+            Fault::TemporaryNoSpace,
+            Fault::TemporarySync,
+            Fault::Replacement,
+        ] {
+            let mut storage = FaultStorage {
+                filesystem: FileRestoreStorage,
+                fault,
+            };
+            assert!(
+                apply_restored_vault_file_with_storage(&destination, &prepared, &mut storage)
+                    .is_err()
+            );
+            assert_eq!(fs::read(&source).expect("source preserved"), SOURCE);
+            assert_eq!(fs::read(&destination).expect("active preserved"), ACTIVE);
+            assert!(fs::read_dir(&directory.0)
+                .expect("directory")
+                .filter_map(Result::ok)
+                .all(|entry| !entry
+                    .file_name()
+                    .to_string_lossy()
+                    .ends_with(".restore.tmp")));
+        }
+    }
+
+    #[test]
+    fn rejected_restore_inputs_preserve_source_and_active_vault() {
+        let directory = TestDirectory::new();
+        let source = directory.0.join("source.sesame");
+        let destination = directory.0.join("active.sesame");
+        fs::write(&destination, ACTIVE).expect("active");
+
+        for (bytes, secret) in [
+            (b"{".to_vec(), PASSWORD),
+            (relabelled_source(), PASSWORD),
+            (SOURCE.to_vec(), "fictional wrong password"),
+        ] {
+            fs::write(&source, &bytes).expect("source case");
+            assert!(prepare_backup_for_restore(&source, &destination, secret).is_err());
+            assert_eq!(fs::read(&source).expect("source preserved"), bytes);
+            assert_eq!(fs::read(&destination).expect("active preserved"), ACTIVE);
+        }
+
+        let future = future_schema_source();
+        fs::write(&source, &future).expect("future source");
+        let error = prepare_backup_for_restore(&source, &destination, PASSWORD)
+            .err()
+            .expect("future schema rejected");
+        assert!(error.contains("vault format 10"));
+        assert!(error.contains("Keep the original backup and contact support."));
+        assert_eq!(fs::read(&source).expect("future source preserved"), future);
+        assert_eq!(fs::read(&destination).expect("active preserved"), ACTIVE);
+
+        fs::write(&source, SOURCE).expect("same source");
+        assert!(prepare_backup_for_restore(&source, &source, PASSWORD).is_err());
+        assert_eq!(fs::read(&source).expect("same source preserved"), SOURCE);
+        let linked_source = directory.0.join("linked-source.sesame");
+        fs::hard_link(&source, &linked_source).expect("linked source");
+        assert!(prepare_backup_for_restore(&linked_source, &source, PASSWORD).is_err());
+        assert_eq!(
+            fs::read(&linked_source).expect("linked source preserved"),
+            SOURCE
+        );
+        assert_eq!(
+            fs::read(&destination).expect("active still preserved"),
+            ACTIVE
+        );
+    }
+
+    #[test]
+    fn invalid_authenticated_migrations_are_rejected_with_recovery_guidance() {
+        let directory = TestDirectory::new();
+        let source = directory.0.join("source.sesame");
+        let destination = directory.0.join("active.sesame");
+        fs::write(&destination, ACTIVE).expect("active");
+        let opened =
+            VaultLoader::load(SOURCE, Credential::MasterPassword(PASSWORD)).expect("opened source");
+
+        for change in [
+            invalid_vault_identity as fn(&mut VaultPayload),
+            invalid_folder,
+            duplicate_active_id,
+            zero_active_revision,
+            dangling_active_folder,
+            duplicate_history_id,
+            zero_history_revision,
+            active_id_in_trash,
+            zero_trash_timestamp,
+        ] {
+            let mut payload = opened.payload.clone();
+            change(&mut payload);
+            let error = validate_migrated_payload(&payload, opened.migration.source_format)
+                .err()
+                .expect("invalid migration rejected");
+            assert!(error.contains("vault format 10"));
+            assert!(error.contains("Keep the original backup and contact support."));
+        }
+
+        let mut file = VaultLoader::parse(SOURCE).expect("source file");
+        file.recovery_kdf = None;
+        file.recovery_wrap = None;
+        let bytes = serde_json::to_vec(&file).expect("source without recovery");
+        fs::write(&source, &bytes).expect("recovery source");
+        let error = prepare_backup_for_restore(&source, &destination, PASSWORD)
+            .err()
+            .expect("missing recovery rejected");
+        assert!(error.contains("recovery access is incomplete"));
+        assert_eq!(fs::read(&source).expect("source preserved"), bytes);
+        assert_eq!(fs::read(&destination).expect("active preserved"), ACTIVE);
+    }
+
+    fn relabelled_source() -> Vec<u8> {
+        let mut file = VaultLoader::parse(SOURCE).expect("source file");
+        file.format_version = 9;
+        serde_json::to_vec(&file).expect("relabelled source")
+    }
+
+    fn future_schema_source() -> Vec<u8> {
+        let mut file = VaultLoader::parse(SOURCE).expect("source file");
+        let key = VaultLoader::unwrap_key(&file, Credential::MasterPassword(PASSWORD))
+            .expect("source key");
+        let aad = crate::payload_aad_for_file(file.format_version, file.setup_complete)
+            .expect("payload label");
+        file.payload = encrypt_bytes(&key, br#"{"items":[{"kind":"future-record"}]}"#, aad)
+            .expect("future payload");
+        serde_json::to_vec(&file).expect("future source")
+    }
+
+    fn duplicate_active_id(payload: &mut VaultPayload) {
+        payload.identities[0].id = payload.entries[0].id.clone();
+    }
+
+    fn invalid_vault_identity(payload: &mut VaultPayload) {
+        payload.vault_id = None;
+    }
+
+    fn invalid_folder(payload: &mut VaultPayload) {
+        payload.folders[0].name.clear();
+    }
+
+    fn dangling_active_folder(payload: &mut VaultPayload) {
+        payload.identities[0].folder_id = Some("missing-folder".into());
+    }
+
+    fn zero_active_revision(payload: &mut VaultPayload) {
+        payload.identities[0].revision = 0;
+    }
+
+    fn duplicate_history_id(payload: &mut VaultPayload) {
+        payload.history.push(payload.history[0].clone());
+    }
+
+    fn zero_history_revision(payload: &mut VaultPayload) {
+        if let TaggedItem::Login(item) = &mut payload.history[0].item {
+            item.revision = 0;
+        }
+    }
+
+    fn active_id_in_trash(payload: &mut VaultPayload) {
+        payload.trash.push(TrashedItem {
+            item: TaggedItem::Login(payload.entries[0].clone()),
+            deleted_at: unix_timestamp(),
+        });
+    }
+
+    fn zero_trash_timestamp(payload: &mut VaultPayload) {
+        payload.trash[0].deleted_at = 0;
+    }
+
+    #[test]
+    fn lifecycle_state_is_cleared_only_after_replacement_succeeds() {
+        let directory = TestDirectory::new();
+        let source = directory.0.join("source.sesame");
+        let destination = directory.0.join("active.sesame");
+        fs::write(&source, SOURCE).expect("source");
+        fs::write(&destination, ACTIVE).expect("active");
+        let opened = VaultLoader::load(SOURCE, Credential::MasterPassword(PASSWORD))
+            .expect("opened fixture");
+        let state = VaultState::default();
+        *state.session.lock().expect("session") =
+            Some(UnlockedVault::from_opened(destination.clone(), &opened).expect("session vault"));
+        let epoch = state.session_epoch();
+
+        let failed: VaultResult<()> =
+            state.apply_lifecycle_replacement(|| Err("replacement failed".into()));
+        assert!(failed.is_err());
+        assert!(state
+            .session
+            .lock()
+            .expect("session after failure")
+            .is_some());
+        assert_eq!(state.session_epoch(), epoch);
+
+        let prepared =
+            prepare_backup_for_restore(&source, &destination, PASSWORD).expect("prepared restore");
+        state
+            .apply_lifecycle_replacement(|| {
+                apply_restored_vault_file(&destination, &prepared).map(|_| ())
+            })
+            .expect("replacement success");
+        assert!(state
+            .session
+            .lock()
+            .expect("session after success")
+            .is_none());
+        assert_eq!(state.session_epoch(), epoch + 1);
+
+        let restarted_file = VaultLoader::read(&destination).expect("restart read");
+        let restarted = VaultLoader::open(&restarted_file, Credential::MasterPassword(PASSWORD))
+            .expect("restart password");
+        VaultLoader::open(&restarted_file, Credential::RecoveryKit(RECOVERY_KIT))
+            .expect("restart recovery");
+        let restarted_state = VaultState::default();
+        *restarted_state.session.lock().expect("restart session") = Some(
+            UnlockedVault::from_opened(destination, &restarted).expect("restarted session vault"),
+        );
+        assert_eq!(
+            restarted_state
+                .session
+                .lock()
+                .expect("restarted session")
+                .as_ref()
+                .expect("unlocked after restart")
+                .snapshot()
+                .vault_id,
+            restarted.payload.vault_id
+        );
+    }
 }

--- a/src-tauri/sesame-core/src/backup.rs
+++ b/src-tauri/sesame-core/src/backup.rs
@@ -4,79 +4,31 @@ use std::path::{Path, PathBuf};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use zeroize::{Zeroize, Zeroizing};
 
-use crate::crypto::{decrypt_bytes, derive_key};
+use crate::loader::{Credential, VaultLoader};
 use crate::platform::unprotect_for_device;
 use crate::storage::write_vault_file;
-use crate::{
-    payload_aad_for_file, VaultFile, VaultPayload, VaultResult, MAX_BACKUP_BYTES,
-    RECOVERY_WRAP_AAD, VAULT_FORMAT_VERSION, WRAP_AAD,
-};
 use crate::{
     types::*,
     util::{random_id, unix_timestamp},
 };
+use crate::{VaultFile, VaultPayload, VaultResult};
 
-/// Master password or recovery kit; the format-2 kit-as-primary-wrap case is tried too.
 pub fn unwrap_vault_key(file: &VaultFile, secret: &str) -> VaultResult<Zeroizing<[u8; 32]>> {
-    let attempts: Vec<(&KdfParams, &CipherBlob, &[u8], String)> = {
-        let mut attempts: Vec<(&KdfParams, &CipherBlob, &[u8], String)> =
-            vec![(&file.kdf, &file.key_wrap, WRAP_AAD, secret.to_string())];
-        let kit = secret.trim().to_ascii_uppercase();
-        match (&file.recovery_kdf, &file.recovery_wrap) {
-            (Some(recovery_kdf), Some(recovery_wrap)) => {
-                attempts.push((recovery_kdf, recovery_wrap, RECOVERY_WRAP_AAD, kit));
-            }
-            // Gated on the stored format: a stripped current-format file must not guess at the master wrap.
-            _ if file.format_version < crate::VAULT_FORMAT_VERSION => {
-                attempts.push((&file.kdf, &file.key_wrap, WRAP_AAD, kit))
-            }
-            _ => {}
-        }
-        attempts
-    };
-
-    for (kdf, wrap, aad, candidate) in attempts {
-        let Ok(wrapping_key) = derive_key(&candidate, kdf) else {
-            continue;
-        };
-        let mut wrapping_key = Zeroizing::new(wrapping_key);
-        if let Ok(mut vault_key) = decrypt_bytes(&wrapping_key, wrap, aad) {
-            let key: Result<[u8; 32], _> = vault_key.as_slice().try_into();
-            vault_key.zeroize();
-            wrapping_key.zeroize();
-            return key
-                .map(Zeroizing::new)
-                .map_err(|_| "That backup contains an invalid vault key.".to_string());
-        }
-        wrapping_key.zeroize();
-    }
-    Err("That master password or recovery kit does not open this backup.".into())
+    VaultLoader::unwrap_key(file, Credential::PasswordOrRecoveryKit(secret)).map_err(Into::into)
 }
 
-/// The secret must unwrap the key, and the key must authenticate the payload.
 pub fn authenticate_vault_file(file: &VaultFile, secret: &str) -> VaultResult<()> {
-    let key = unwrap_vault_key(file, secret)?;
-    let payload_aad = payload_aad_for_file(file.format_version, file.setup_complete)?;
-    let payload_bytes = Zeroizing::new(decrypt_bytes(&key, &file.payload, payload_aad).map_err(
-        |_| "That backup is damaged. Its contents could not be authenticated.".to_string(),
-    )?);
-    let mut payload: VaultPayload = serde_json::from_slice(payload_bytes.as_slice())
-        .map_err(|_| "That backup is damaged. Its contents could not be read.".to_string())?;
-    payload.zeroize();
-    Ok(())
+    VaultLoader::authenticate(file, Credential::PasswordOrRecoveryKit(secret))
+        .map(|_| ())
+        .map_err(Into::into)
 }
 
-/// Non-destructive; only display-safe metadata leaves this function.
 pub fn verify_backup_file(path: &Path, secret: &str) -> VaultResult<BackupVerification> {
     let file = read_backup_file(path)?;
-    let key = unwrap_vault_key(&file, secret)?;
-    let payload_aad = payload_aad_for_file(file.format_version, file.setup_complete)?;
-    let payload_bytes = Zeroizing::new(decrypt_bytes(&key, &file.payload, payload_aad).map_err(
-        |_| "That backup is damaged. Its contents could not be authenticated.".to_string(),
-    )?);
-    let mut payload: VaultPayload = serde_json::from_slice(payload_bytes.as_slice())
-        .map_err(|_| "That backup is damaged. Its contents could not be read.".to_string())?;
-    let verification = BackupVerification {
+    let authenticated =
+        VaultLoader::authenticate(&file, Credential::PasswordOrRecoveryKit(secret))?;
+    let payload = authenticated.payload();
+    Ok(BackupVerification {
         file_name: path
             .file_name()
             .and_then(|name| name.to_str())
@@ -87,9 +39,7 @@ pub fn verify_backup_file(path: &Path, secret: &str) -> VaultResult<BackupVerifi
         entry_count: payload.entries.len(),
         vault_id: payload.vault_id.clone(),
         revision: payload.revision,
-    };
-    payload.zeroize();
-    Ok(verification)
+    })
 }
 
 /// Device-bound material on another profile can never be used again.
@@ -415,49 +365,9 @@ pub fn read_backup_file(path: &Path) -> VaultResult<VaultFile> {
     if path.extension().and_then(|extension| extension.to_str()) != Some("sesame") {
         return Err("Choose a Sesame backup with a .sesame extension.".into());
     }
-    let bytes = crate::util::require_file_with_limit(
-        path,
-        MAX_BACKUP_BYTES,
-        "Sesame could not read that backup file.",
-    )?;
-    let file: VaultFile = serde_json::from_slice(&bytes)
-        .map_err(|_| "That file is not a valid Sesame encrypted backup.".to_string())?;
-    validate_backup_file(&file)?;
-    Ok(file)
+    VaultLoader::read(path).map_err(Into::into)
 }
 
 pub fn validate_backup_file(file: &VaultFile) -> VaultResult<()> {
-    if file.format_version == 0 || file.format_version > VAULT_FORMAT_VERSION {
-        return Err("That backup uses a Sesame format this version cannot restore.".into());
-    }
-    crate::crypto::validate_kdf_params(&file.kdf)
-        .map_err(|_| "That backup has invalid key-derivation settings.".to_string())?;
-    if let Some(recovery_kdf) = &file.recovery_kdf {
-        crate::crypto::validate_kdf_params(recovery_kdf)
-            .map_err(|_| "That backup has invalid recovery key-derivation settings.".to_string())?;
-    }
-    validate_cipher_blob(&file.key_wrap)?;
-    if let Some(recovery_wrap) = &file.recovery_wrap {
-        validate_cipher_blob(recovery_wrap)?;
-    }
-    if let Some(pin_wrap) = &file.pin_wrap {
-        crate::crypto::validate_kdf_params(&pin_wrap.kdf)
-            .map_err(|_| "That backup has invalid PIN key-derivation settings.".to_string())?;
-        validate_cipher_blob(&pin_wrap.key_wrap)?;
-    }
-    validate_cipher_blob(&file.payload)?;
-    Ok(())
-}
-
-fn validate_cipher_blob(blob: &CipherBlob) -> VaultResult<()> {
-    let nonce = URL_SAFE_NO_PAD
-        .decode(&blob.nonce)
-        .map_err(|_| "That backup contains invalid encrypted data.".to_string())?;
-    let ciphertext = URL_SAFE_NO_PAD
-        .decode(&blob.ciphertext)
-        .map_err(|_| "That backup contains invalid encrypted data.".to_string())?;
-    if nonce.len() != 24 || ciphertext.len() < 16 {
-        return Err("That backup contains invalid encrypted data.".into());
-    }
-    Ok(())
+    VaultLoader::validate(file).map_err(Into::into)
 }

--- a/src-tauri/sesame-core/src/lib.rs
+++ b/src-tauri/sesame-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod crypto;
 pub mod ffi;
 pub mod history;
 pub mod imports;
+pub mod loader;
 pub mod migration;
 pub mod password_analysis;
 pub mod pending_import;

--- a/src-tauri/sesame-core/src/lib.rs
+++ b/src-tauri/sesame-core/src/lib.rs
@@ -189,14 +189,33 @@ impl VaultState {
     pub fn begin_destructive_lifecycle_change(
         &self,
     ) -> VaultResult<std::sync::MutexGuard<'_, Option<UnlockedVault>>> {
-        let mut session = self
-            .session
-            .lock()
-            .map_err(|_| "Sesame could not close the current vault session.".to_string())?;
+        let mut session = self.begin_lifecycle_change()?;
         *session = None;
         self.discard_pending_import();
         self.advance_session_epoch();
         Ok(session)
+    }
+
+    fn begin_lifecycle_change(
+        &self,
+    ) -> VaultResult<std::sync::MutexGuard<'_, Option<UnlockedVault>>> {
+        self.session
+            .lock()
+            .map_err(|_| "Sesame could not close the current vault session.".to_string())
+    }
+
+    pub fn apply_lifecycle_replacement<T>(
+        &self,
+        replace: impl FnOnce() -> VaultResult<T>,
+    ) -> VaultResult<T> {
+        let mut session = self.begin_lifecycle_change()?;
+        let result = replace();
+        if result.is_ok() {
+            *session = None;
+            self.discard_pending_import();
+            self.advance_session_epoch();
+        }
+        result
     }
 
     pub fn lock_for_lifecycle(&self) -> VaultResult<()> {

--- a/src-tauri/sesame-core/src/loader.rs
+++ b/src-tauri/sesame-core/src/loader.rs
@@ -111,16 +111,23 @@ pub struct VaultLoader;
 
 impl VaultLoader {
     pub fn read(path: &Path) -> LoadResult<VaultFile> {
+        let bytes = Self::read_bytes(path)?;
+        Self::parse(&bytes)
+    }
+
+    pub fn read_bytes(path: &Path) -> LoadResult<Zeroizing<Vec<u8>>> {
         let file = std::fs::File::open(path).map_err(|_| LoadFailure::LocalIo)?;
         if file.metadata().map_err(|_| LoadFailure::LocalIo)?.len() > MAX_VAULT_FILE_BYTES {
             return Err(LoadFailure::SizeLimit);
         }
-        // Bound the read itself: the file can grow after its metadata was checked.
         let mut bytes = Vec::new();
         file.take(MAX_VAULT_FILE_BYTES + 1)
             .read_to_end(&mut bytes)
             .map_err(|_| LoadFailure::LocalIo)?;
-        Self::parse(&bytes)
+        if bytes.len() as u64 > MAX_VAULT_FILE_BYTES {
+            return Err(LoadFailure::SizeLimit);
+        }
+        Ok(Zeroizing::new(bytes))
     }
 
     pub fn parse(bytes: &[u8]) -> LoadResult<VaultFile> {

--- a/src-tauri/sesame-core/src/loader.rs
+++ b/src-tauri/sesame-core/src/loader.rs
@@ -1,0 +1,333 @@
+//! The boundary from bounded, untrusted envelopes to authenticated vault contents.
+
+use std::{fmt, io::Read, path::Path};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use zeroize::Zeroizing;
+
+use crate::{
+    api::OpenedVault,
+    crypto::{decrypt_bytes, derive_key, validate_kdf_params},
+    migration::{migrate_payload, migrate_vault_file, MIN_SUPPORTED_VAULT_FORMAT},
+    payload_aad_for_file, CipherBlob, VaultFile, VaultPayload, MAX_VAULT_FILE_BYTES,
+    RECOVERY_WRAP_AAD, VAULT_FORMAT_VERSION, WRAP_AAD,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LoadFailure {
+    WrongPassword,
+    WrongRecoveryKit,
+    WrongSecret,
+    Authentication,
+    RecoveryRequired { format: u8 },
+    NewerFormat { format: u8 },
+    UnsupportedFormat { format: u8 },
+    InvalidStructure,
+    UnsafeKdf,
+    SizeLimit,
+    LocalIo,
+}
+
+impl fmt::Display for LoadFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::WrongPassword => "Sesame could not unlock this vault. Check your master password.",
+            Self::WrongRecoveryKit => "That recovery kit is not correct.",
+            Self::WrongSecret => "That master password or recovery kit does not open this backup.",
+            Self::Authentication => "The vault data could not be authenticated. Restore a known-good encrypted backup.",
+            Self::RecoveryRequired { .. } => "The authenticated vault schema needs a recovery path. Keep the original backup and contact support.",
+            Self::NewerFormat { .. } => "This vault requires a newer version of Sesame.",
+            Self::UnsupportedFormat { .. } => "This vault uses a format Sesame does not understand yet.",
+            Self::InvalidStructure => "This vault file is not valid. Restore a known-good encrypted backup.",
+            Self::UnsafeKdf => "The vault key-derivation settings are outside Sesame's safe limits.",
+            Self::SizeLimit => "This vault file exceeds Sesame's size limit.",
+            Self::LocalIo => "Sesame could not read the vault file.",
+        })
+    }
+}
+
+impl std::error::Error for LoadFailure {}
+
+impl From<LoadFailure> for String {
+    fn from(value: LoadFailure) -> Self {
+        value.to_string()
+    }
+}
+
+pub type LoadResult<T> = Result<T, LoadFailure>;
+
+pub enum Credential<'a> {
+    MasterPassword(&'a str),
+    RecoveryKit(&'a str),
+    /// Preserves the existing backup/FFI single-field credential contract.
+    PasswordOrRecoveryKit(&'a str),
+    /// The host has already authorized and opened a PIN or device wrapper.
+    VaultKey(&'a [u8; 32]),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FormatState {
+    Current,
+    NeedsMigration,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Inspection {
+    pub format: u8,
+    pub state: FormatState,
+    pub setup_complete: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MigrationPlan {
+    pub source_format: u8,
+    pub target_format: u8,
+    pub envelope_changed: bool,
+    pub payload_changed: bool,
+}
+
+impl MigrationPlan {
+    pub fn required(self) -> bool {
+        self.envelope_changed || self.payload_changed
+    }
+}
+
+pub struct AuthenticatedPayload {
+    bytes: Zeroizing<Vec<u8>>,
+    payload: Zeroizing<VaultPayload>,
+}
+
+impl AuthenticatedPayload {
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn payload(&self) -> &VaultPayload {
+        &self.payload
+    }
+}
+
+pub struct VaultLoader;
+
+impl VaultLoader {
+    pub fn read(path: &Path) -> LoadResult<VaultFile> {
+        let file = std::fs::File::open(path).map_err(|_| LoadFailure::LocalIo)?;
+        if file.metadata().map_err(|_| LoadFailure::LocalIo)?.len() > MAX_VAULT_FILE_BYTES {
+            return Err(LoadFailure::SizeLimit);
+        }
+        // Bound the read itself: the file can grow after its metadata was checked.
+        let mut bytes = Vec::new();
+        file.take(MAX_VAULT_FILE_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| LoadFailure::LocalIo)?;
+        Self::parse(&bytes)
+    }
+
+    pub fn parse(bytes: &[u8]) -> LoadResult<VaultFile> {
+        if bytes.len() as u64 > MAX_VAULT_FILE_BYTES {
+            return Err(LoadFailure::SizeLimit);
+        }
+        let file = serde_json::from_slice(bytes).map_err(|_| LoadFailure::InvalidStructure)?;
+        Self::validate(&file)?;
+        Ok(file)
+    }
+
+    pub fn inspect(bytes: &[u8]) -> LoadResult<Inspection> {
+        let file = Self::parse(bytes)?;
+        Ok(Inspection {
+            format: file.format_version,
+            state: if file.format_version < VAULT_FORMAT_VERSION {
+                FormatState::NeedsMigration
+            } else {
+                FormatState::Current
+            },
+            setup_complete: file.setup_complete,
+        })
+    }
+
+    pub fn validate(file: &VaultFile) -> LoadResult<()> {
+        let format = file.format_version;
+        if format > VAULT_FORMAT_VERSION {
+            return Err(LoadFailure::NewerFormat { format });
+        }
+        if format < MIN_SUPPORTED_VAULT_FORMAT {
+            return Err(LoadFailure::UnsupportedFormat { format });
+        }
+        payload_aad_for_file(format, file.setup_complete)
+            .map_err(|_| LoadFailure::InvalidStructure)?;
+        for kdf in std::iter::once(&file.kdf)
+            .chain(file.recovery_kdf.iter())
+            .chain(file.pin_wrap.iter().map(|wrap| &wrap.kdf))
+        {
+            validate_kdf_params(kdf).map_err(|_| LoadFailure::UnsafeKdf)?;
+            argon2::Params::new(kdf.memory_kib, kdf.iterations, kdf.parallelism, Some(32))
+                .map_err(|_| LoadFailure::UnsafeKdf)?;
+        }
+        if file.recovery_kdf.is_some() != file.recovery_wrap.is_some() {
+            return Err(LoadFailure::InvalidStructure);
+        }
+        for blob in std::iter::once(&file.key_wrap)
+            .chain(std::iter::once(&file.payload))
+            .chain(file.recovery_wrap.iter())
+            .chain(file.pin_wrap.iter().map(|wrap| &wrap.key_wrap))
+        {
+            validate_blob(blob)?;
+        }
+        Ok(())
+    }
+
+    pub fn load(bytes: &[u8], credential: Credential<'_>) -> LoadResult<OpenedVault> {
+        Self::open(&Self::parse(bytes)?, credential)
+    }
+
+    pub fn unwrap_key(
+        file: &VaultFile,
+        credential: Credential<'_>,
+    ) -> LoadResult<Zeroizing<[u8; 32]>> {
+        Self::validate(file)?;
+        match credential {
+            Credential::VaultKey(key) => Ok(Zeroizing::new(*key)),
+            Credential::MasterPassword(password) => unwrap(
+                password,
+                &file.kdf,
+                &file.key_wrap,
+                WRAP_AAD,
+                LoadFailure::WrongPassword,
+            ),
+            Credential::RecoveryKit(kit) => {
+                let normalized = Zeroizing::new(kit.trim().to_ascii_uppercase());
+                match (&file.recovery_kdf, &file.recovery_wrap) {
+                    (Some(kdf), Some(wrap)) => unwrap(
+                        &normalized,
+                        kdf,
+                        wrap,
+                        RECOVERY_WRAP_AAD,
+                        LoadFailure::WrongRecoveryKit,
+                    ),
+                    _ if file.format_version < VAULT_FORMAT_VERSION => unwrap(
+                        &normalized,
+                        &file.kdf,
+                        &file.key_wrap,
+                        WRAP_AAD,
+                        LoadFailure::WrongRecoveryKit,
+                    ),
+                    _ => Err(LoadFailure::InvalidStructure),
+                }
+            }
+            Credential::PasswordOrRecoveryKit(secret) => {
+                match Self::unwrap_key(file, Credential::MasterPassword(secret)) {
+                    Err(LoadFailure::WrongPassword) => {
+                        match Self::unwrap_key(file, Credential::RecoveryKit(secret)) {
+                            Err(LoadFailure::WrongRecoveryKit | LoadFailure::InvalidStructure) => {
+                                Err(LoadFailure::WrongSecret)
+                            }
+                            other => other,
+                        }
+                    }
+                    other => other,
+                }
+            }
+        }
+    }
+
+    pub fn authenticate(
+        file: &VaultFile,
+        credential: Credential<'_>,
+    ) -> LoadResult<AuthenticatedPayload> {
+        let key = Self::unwrap_key(file, credential)?;
+        authenticate_payload(file, &key)
+    }
+
+    pub fn open(file: &VaultFile, credential: Credential<'_>) -> LoadResult<OpenedVault> {
+        let key = Self::unwrap_key(file, credential)?;
+        let authenticated = authenticate_payload(file, &key)?;
+        let mut payload = authenticated.payload().clone();
+        let mut next_file = file.clone();
+        let envelope_changed =
+            migrate_vault_file(&mut next_file).map_err(|_| LoadFailure::UnsupportedFormat {
+                format: file.format_version,
+            })?;
+        let payload_changed = migrate_payload(&mut payload);
+        let migration = MigrationPlan {
+            source_format: file.format_version,
+            target_format: next_file.format_version,
+            envelope_changed,
+            payload_changed,
+        };
+        Ok(OpenedVault {
+            key,
+            payload,
+            file: next_file,
+            migrated: migration.required(),
+            migration,
+        })
+    }
+
+    /// Sync signatures, membership, revision and epoch checks remain at the host seam.
+    /// The caller supplies the exact protocol AAD, never a fallback vault-file label.
+    pub fn open_snapshot(
+        version: u32,
+        key: &[u8; 32],
+        blob: &CipherBlob,
+        aad: &[u8],
+    ) -> LoadResult<AuthenticatedPayload> {
+        if version != 2 {
+            return Err(LoadFailure::InvalidStructure);
+        }
+        validate_blob(blob)?;
+        let bytes =
+            Zeroizing::new(decrypt_bytes(key, blob, aad).map_err(|_| LoadFailure::Authentication)?);
+        decode(bytes, VAULT_FORMAT_VERSION)
+    }
+}
+
+fn authenticate_payload(file: &VaultFile, key: &[u8; 32]) -> LoadResult<AuthenticatedPayload> {
+    let aad = payload_aad_for_file(file.format_version, file.setup_complete)
+        .map_err(|_| LoadFailure::InvalidStructure)?;
+    let bytes = Zeroizing::new(
+        decrypt_bytes(key, &file.payload, aad).map_err(|_| LoadFailure::Authentication)?,
+    );
+    decode(bytes, file.format_version)
+}
+
+fn decode(bytes: Zeroizing<Vec<u8>>, format: u8) -> LoadResult<AuthenticatedPayload> {
+    let payload =
+        serde_json::from_slice(&bytes).map_err(|_| LoadFailure::RecoveryRequired { format })?;
+    Ok(AuthenticatedPayload {
+        bytes,
+        payload: Zeroizing::new(payload),
+    })
+}
+
+fn unwrap(
+    secret: &str,
+    kdf: &crate::KdfParams,
+    blob: &CipherBlob,
+    aad: &[u8],
+    failure: LoadFailure,
+) -> LoadResult<Zeroizing<[u8; 32]>> {
+    let wrapping_key = Zeroizing::new(derive_key(secret, kdf).map_err(|_| LoadFailure::UnsafeKdf)?);
+    // AEAD cannot distinguish an incorrect credential from a damaged wrapper.
+    let bytes = Zeroizing::new(decrypt_bytes(&wrapping_key, blob, aad).map_err(|_| failure)?);
+    bytes
+        .as_slice()
+        .try_into()
+        .map(Zeroizing::new)
+        .map_err(|_| LoadFailure::InvalidStructure)
+}
+
+fn validate_blob(blob: &CipherBlob) -> LoadResult<()> {
+    if blob.ciphertext.len() as u64 > MAX_VAULT_FILE_BYTES || blob.nonce.len() > 32 {
+        return Err(LoadFailure::SizeLimit);
+    }
+    let nonce = URL_SAFE_NO_PAD
+        .decode(&blob.nonce)
+        .map_err(|_| LoadFailure::InvalidStructure)?;
+    let ciphertext = URL_SAFE_NO_PAD
+        .decode(&blob.ciphertext)
+        .map_err(|_| LoadFailure::InvalidStructure)?;
+    if nonce.len() != 24 || ciphertext.len() < 16 {
+        return Err(LoadFailure::InvalidStructure);
+    }
+    Ok(())
+}

--- a/src-tauri/sesame-core/src/migration.rs
+++ b/src-tauri/sesame-core/src/migration.rs
@@ -13,7 +13,7 @@ pub fn fresh_vault_id() -> String {
 pub const MIN_SUPPORTED_VAULT_FORMAT: u8 = 2;
 
 /// Removes the dead format-2 device wrap; returns whether the caller must rewrite the file.
-pub fn migrate_vault_file(file: &mut VaultFile) -> VaultResult<bool> {
+pub(crate) fn migrate_vault_file(file: &mut VaultFile) -> VaultResult<bool> {
     if file.format_version < MIN_SUPPORTED_VAULT_FORMAT
         || file.format_version > VAULT_FORMAT_VERSION
     {
@@ -34,7 +34,7 @@ pub fn migrate_vault_file(file: &mut VaultFile) -> VaultResult<bool> {
 }
 
 /// Pre-metadata creation times are stamped at migration, never invented.
-pub fn migrate_payload(payload: &mut VaultPayload) -> bool {
+pub(crate) fn migrate_payload(payload: &mut VaultPayload) -> bool {
     let now = unix_timestamp();
     let mut changed = false;
 

--- a/src-tauri/sesame-core/src/platform/fs.rs
+++ b/src-tauri/sesame-core/src/platform/fs.rs
@@ -102,7 +102,8 @@ pub fn same_file_identity(source: &Path, destination: &Path) -> bool {
     use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::Storage::FileSystem::{
         CreateFileW, GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
-        FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        OPEN_EXISTING,
     };
 
     // std keeps Windows file identity unstable, so two open handles are

--- a/src-tauri/sesame-core/src/platform/fs.rs
+++ b/src-tauri/sesame-core/src/platform/fs.rs
@@ -96,6 +96,67 @@ pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
         .map_err(|_| "Sesame could not write the vault copy.".to_string())
 }
 
+#[cfg(windows)]
+pub fn same_file_identity(source: &Path, destination: &Path) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    // std keeps Windows file identity unstable, so two open handles are
+    // compared by volume serial number and file index.
+    fn file_identity(path: &Path) -> Option<(u32, u64)> {
+        let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            return None;
+        }
+        let mut information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+        let queried = unsafe { GetFileInformationByHandle(handle, &mut information) };
+        unsafe { CloseHandle(handle) };
+        if queried == 0 {
+            return None;
+        }
+        Some((
+            information.dwVolumeSerialNumber,
+            ((information.nFileIndexHigh as u64) << 32) | information.nFileIndexLow as u64,
+        ))
+    }
+
+    match (file_identity(source), file_identity(destination)) {
+        (Some(source), Some(destination)) => source == destination,
+        _ => false,
+    }
+}
+
+#[cfg(unix)]
+pub fn same_file_identity(source: &Path, destination: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    match (fs::metadata(source), fs::metadata(destination)) {
+        (Ok(source), Ok(destination)) => {
+            source.dev() == destination.dev() && source.ino() == destination.ino()
+        }
+        _ => false,
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn same_file_identity(_source: &Path, _destination: &Path) -> bool {
+    false
+}
+
 /// Best-effort secure deletion: overwrites with random bytes; wear-leveled storage cannot be guaranteed.
 pub fn securely_delete(path: &Path) -> VaultResult<()> {
     if path.is_dir() {

--- a/src-tauri/sesame-core/src/platform/mod.rs
+++ b/src-tauri/sesame-core/src/platform/mod.rs
@@ -18,7 +18,8 @@ pub use linux::{device_protection_available, protect_for_device, unprotect_for_d
 
 mod fs;
 pub use fs::{
-    copy_private_file, create_private_dir, open_private_file, replace_file, securely_delete,
+    copy_private_file, create_private_dir, open_private_file, replace_file, same_file_identity,
+    securely_delete,
 };
 
 #[cfg(not(any(windows, target_os = "linux")))]

--- a/src-tauri/sesame-core/src/storage.rs
+++ b/src-tauri/sesame-core/src/storage.rs
@@ -30,13 +30,7 @@ pub const PIN_THROTTLE_FILE: &str = "pin-throttle.sesame";
 
 /// Every unlock path runs this before deriving a key from the file's parameters.
 pub fn check_supported_vault_format(file: &VaultFile) -> VaultResult<()> {
-    if file.format_version == 0
-        || file.format_version > VAULT_FORMAT_VERSION
-        || file.kdf.algorithm != "argon2id"
-    {
-        return Err("This vault uses a format Sesame does not understand yet.".into());
-    }
-    Ok(())
+    crate::loader::VaultLoader::validate(file).map_err(Into::into)
 }
 
 /// Absent reads as tampering, not a fresh count: setting a PIN always writes it.

--- a/src-tauri/sesame-core/tests/compatibility_corpus.rs
+++ b/src-tauri/sesame-core/tests/compatibility_corpus.rs
@@ -3,11 +3,8 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use serde_json::Value;
-use sesame_core::api::{
-    open_vault, open_vault_with_recovery_kit, parse_vault_file, unwrap_key_with_password,
-};
-use sesame_core::backup::{authenticate_vault_file, read_backup_file};
-use sesame_core::{decrypt_bytes, migrate_vault_file, payload_aad_for_file, VAULT_FORMAT_VERSION};
+use sesame_core::loader::{Credential, VaultLoader};
+use sesame_core::VAULT_FORMAT_VERSION;
 use sha2::{Digest, Sha256};
 
 const PUBLISHED_RELEASES: [&str; 5] = ["v0.1.0", "v0.1.1", "v0.2.0", "v0.2.1", "v0.2.2"];
@@ -127,7 +124,7 @@ fn open_fixture(tag: &str) {
         "{tag} no longer matches its recorded digest"
     );
 
-    let file = read_backup_file(&path).expect("the current reader accepts the fixture");
+    let file = VaultLoader::read(&path).expect("the current reader accepts the fixture");
     assert_eq!(file.format_version, VAULT_FORMAT_VERSION);
     assert!(file.setup_complete);
 
@@ -137,24 +134,10 @@ fn open_fixture(tag: &str) {
     let recovery_kit = entry["secrets"]["recoveryKit"]
         .as_str()
         .expect("recovery kit");
-    authenticate_vault_file(&file, master_password)
-        .expect("master password authenticates the fixture");
-
-    let mut migrated_file = file.clone();
-    let file_changed = migrate_vault_file(&mut migrated_file).expect("file migration runs");
-    assert_eq!(
-        file_changed,
-        entry["expectedMigration"]["fileChanged"]
-            .as_bool()
-            .expect("fileChanged"),
-        "{tag} file migration did not match its recorded expectation"
-    );
-
-    let key = unwrap_key_with_password(&file, master_password).expect("unwrapped the vault key");
-    let payload_aad = payload_aad_for_file(file.format_version, file.setup_complete)
-        .expect("payload label for the recorded format");
-    let payload_bytes =
-        decrypt_bytes(&key, &file.payload, payload_aad).expect("decrypted the recorded payload");
+    let authenticated =
+        VaultLoader::authenticate(&file, Credential::MasterPassword(master_password))
+            .expect("master password authenticates the fixture");
+    let payload_bytes = authenticated.bytes();
     let raw_payload: Value =
         serde_json::from_slice(&payload_bytes).expect("parsed the decrypted payload");
     let items = raw_payload["items"].as_array().expect("tagged items shape");
@@ -177,7 +160,20 @@ fn open_fixture(tag: &str) {
         "{tag} identity tags key presence did not match its recorded payload shape"
     );
 
-    let opened = open_vault(&file, master_password).expect("opened the fixture");
+    let opened = VaultLoader::open(&file, Credential::MasterPassword(master_password))
+        .expect("opened the fixture");
+    assert_eq!(
+        opened.migration.envelope_changed,
+        entry["expectedMigration"]["fileChanged"]
+            .as_bool()
+            .expect("fileChanged")
+    );
+    assert_eq!(
+        opened.migration.payload_changed,
+        entry["expectedMigration"]["payloadChanged"]
+            .as_bool()
+            .expect("payloadChanged")
+    );
     assert!(
         opened.migrated,
         "{tag} authenticated payload must report its migration state"
@@ -245,8 +241,8 @@ fn open_fixture(tag: &str) {
     assert_eq!(backfilled.password_updated_at, backfilled.updated_at);
     assert_eq!(backfilled.revision, 1);
 
-    let reparsed = parse_vault_file(&bytes).expect("reparsed the fixture bytes");
-    let with_kit = open_vault_with_recovery_kit(&reparsed, recovery_kit)
+    let reparsed = VaultLoader::parse(&bytes).expect("reparsed the fixture bytes");
+    let with_kit = VaultLoader::open(&reparsed, Credential::RecoveryKit(recovery_kit))
         .expect("recovery kit opens the fixture");
     assert_eq!(with_kit.payload.vault_id, opened.payload.vault_id);
 

--- a/src-tauri/sesame-core/tests/fixtures/compatibility/manifest.json
+++ b/src-tauri/sesame-core/tests/fixtures/compatibility/manifest.json
@@ -7,27 +7,72 @@
     {
       "tag": "v0.1.0",
       "commit": "cd8062eae660a5a1ff04723801e40038d0ea8949",
-      "writerGeneration": "legacy"
+      "writerGeneration": "legacy",
+      "publishedAt": "2026-08-18T17:39:37Z",
+      "releaseUrl": "https://github.com/usesesame/sesame-desktop/releases/tag/v0.1.0",
+      "packages": [
+        {
+          "digest": "sha256:85e1adf61290b4771c3f3ad8744e28d61db50939057e1637e7eb22b27e3efa90",
+          "name": "Sesame_0.1.0_x64-setup.exe",
+          "size": 6179098
+        }
+      ]
     },
     {
       "tag": "v0.1.1",
       "commit": "0bf94b71681a41d8dbb5d4679428f5a69c1a35f7",
-      "writerGeneration": "legacy"
+      "writerGeneration": "legacy",
+      "publishedAt": "2026-08-19T08:25:41Z",
+      "releaseUrl": "https://github.com/usesesame/sesame-desktop/releases/tag/v0.1.1",
+      "packages": [
+        {
+          "digest": "sha256:7123941ea6b92e8095c51d31f761101cb9ee31d2176f66741b71bcdd0e9edd52",
+          "name": "Sesame_0.1.1_x64-setup.exe",
+          "size": 6241309
+        }
+      ]
     },
     {
       "tag": "v0.2.0",
       "commit": "70420cb69d674fb67725f244cd9ca831827b9a87",
-      "writerGeneration": "current"
+      "writerGeneration": "current",
+      "publishedAt": "2026-08-30T15:35:29Z",
+      "releaseUrl": "https://github.com/usesesame/sesame-desktop/releases/tag/v0.2.0",
+      "packages": [
+        {
+          "digest": "sha256:4517fcdf3bcc16db76a7db4459c75d1ad0a859162dae2b6f32d89f98cdd6107a",
+          "name": "Sesame_0.2.0_x64-setup.exe",
+          "size": 6241236
+        }
+      ]
     },
     {
       "tag": "v0.2.1",
       "commit": "ad4339a2e07ecb8216da81a5d5cf72a70444e000",
-      "writerGeneration": "current"
+      "writerGeneration": "current",
+      "publishedAt": "2026-08-31T07:57:42Z",
+      "releaseUrl": "https://github.com/usesesame/sesame-desktop/releases/tag/v0.2.1",
+      "packages": [
+        {
+          "digest": "sha256:4e9cc735f0810e9f7462f6d7c5a9c35135fde77c89c8e11e5231115653a6d2d1",
+          "name": "Sesame_0.2.1_x64-setup.exe",
+          "size": 6242103
+        }
+      ]
     },
     {
       "tag": "v0.2.2",
       "commit": "39984ed621a5c1fef3d56b94d55f3ee1901a0543",
-      "writerGeneration": "current"
+      "writerGeneration": "current",
+      "publishedAt": "2026-08-31T12:22:21Z",
+      "releaseUrl": "https://github.com/usesesame/sesame-desktop/releases/tag/v0.2.2",
+      "packages": [
+        {
+          "digest": "sha256:fd91d0ed65f1e1ff346784666bcee3b414a1238419cb490ca6dc7addd3c32a22",
+          "name": "Sesame_0.2.2_x64-setup.exe",
+          "size": 6239692
+        }
+      ]
     }
   ],
   "writerGenerations": [
@@ -85,6 +130,16 @@
         "recordedBy": "owner",
         "date": "2026-09-02",
         "note": "The owner kept the upgrade path: readers for formats 2 through 9 stay, so an old file can always be upgraded into the current format instead of being refused. Support for these formats is enforced by the authenticated format-bound construction and adversarial reader tests, not by genuine writer fixtures. Every public release wrote format 10, so public-release users are covered by the proven fixtures; formats 2 through 9 only matter for backups from builds that never shipped."
+      },
+      "recoveryPath": {
+        "status": "requiresHistoricalWriter",
+        "steps": [
+          "Recover the original pre-public source revision and lockfile, or original executable and its provenance, from maintainer archives for each format 2 through 9. The public tags and reachable format-constant history do not contain these writers.",
+          "Identify the exact envelope, payload schema, KDF parameters, wrapper construction, authentication labels, and setup states from that writer. Do not infer them by relabelling a format 10 file or trying alternate authentication labels.",
+          "Run the recovered writer in an isolated environment with fictional data for every available record type, folders, trash, history, Unicode, empty optionals, and each supported recovery path. Record the writer digest, fixture digest, fictional credentials, stable identifiers, and expected decoded contents.",
+          "Require those genuine fixtures to authenticate and preserve their expected contents through the compatibility tests before describing that format as proven. If its reader must be retired, obtain owner approval for a separately retained read-only recovery build or converter and test it against the same fixtures first."
+        ],
+        "limitation": "Keeping existing readers does not establish historical compatibility. No recovered writer, tested standalone converter, or approved removal from the compatibility promise is recorded for formats 2 through 9."
       }
     }
   ],
@@ -554,5 +609,52 @@
         }
       }
     }
-  ]
+  ],
+  "releaseInventory": {
+    "checkedAt": "2026-09-05",
+    "source": "https://api.github.com/repos/usesesame/sesame-desktop/releases",
+    "scope": "All public releases and installable assets returned by the paginated release API. Package digests are GitHub metadata, not locally verified downloads. Fixtures use tagged source writers, not installed packages."
+  },
+  "writerInventory": {
+    "scope": "Tagged source writers for the five published releases; installed-package execution was not repeated in this review.",
+    "sourcePaths": [
+      "src-tauri/sesame-core/src/lib.rs",
+      "src-tauri/sesame-core/src/api.rs",
+      "src-tauri/sesame-core/src/crypto.rs",
+      "src-tauri/sesame-core/src/storage.rs",
+      "src-tauri/sesame-core/src/types.rs"
+    ],
+    "formatVersion": 10,
+    "envelope": "JSON VaultFile with formatVersion, kdf, keyWrap, optional deviceWrap, recoveryKdf, recoveryWrap, pinWrap, helloWrap, setupComplete, and payload.",
+    "payload": "JSON PersistedVaultPayloadV8 with tagged items, folders, trash, history, vaultName, vaultId, and revision. Record-field differences are recorded in writerGenerations and each fixture payloadShape.",
+    "cipher": "XChaCha20-Poly1305 with 32-byte keys and 24-byte random nonces; base64url without padding for encoded bytes.",
+    "passwordAndRecoveryKdf": {
+      "algorithm": "argon2id",
+      "version": 19,
+      "memoryKib": 65536,
+      "iterations": 3,
+      "parallelism": 4,
+      "saltBytes": 32,
+      "outputBytes": 32
+    },
+    "authenticationLabels": {
+      "passwordWrap": "sesame:wrapped-vault-key:v1",
+      "recoveryWrap": "sesame:recovery-wrapped-vault-key:v1",
+      "pinWrap": "sesame:pin-wrapped-vault-key:v1",
+      "pendingPayload": "sesame:vault-payload:format:10:setup:pending",
+      "completePayload": "sesame:vault-payload:format:10:setup:complete"
+    },
+    "fixtureWrappers": [
+      "masterPassword",
+      "recoveryKit"
+    ],
+    "fixtureSetupStates": [
+      "complete"
+    ],
+    "coverageLimits": [
+      "No pending-setup fixture is committed.",
+      "No PIN, Windows Hello, or legacy device wrapper fixture is committed.",
+      "No installed-package execution or restore/restart round trip is established by the read-only corpus tests."
+    ]
+  }
 }

--- a/src-tauri/sesame-core/tests/transactional_restore.rs
+++ b/src-tauri/sesame-core/tests/transactional_restore.rs
@@ -1,0 +1,331 @@
+use std::{fs, path::PathBuf};
+
+use sesame_core::{
+    backup::{apply_restored_vault_file, prepare_backup_for_restore},
+    crypto::serialize_payload,
+    loader::{Credential, VaultLoader},
+    random_id, VAULT_FORMAT_VERSION,
+};
+
+const MANIFEST: &str = include_str!("fixtures/compatibility/manifest.json");
+const ACTIVE: &[u8] = include_bytes!("fixtures/compatibility/v0.2.2.sesame");
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!("sesame-transaction-{}", random_id()));
+        fs::create_dir(&path).expect("test directory");
+        Self(path)
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn restore_fixture(file_name: &str) {
+    let manifest: serde_json::Value = serde_json::from_str(MANIFEST).expect("manifest");
+    let fixtures = manifest["fixtures"].as_array().expect("fixtures");
+    let entry = fixtures
+        .iter()
+        .find(|entry| entry["fileName"].as_str() == Some(file_name))
+        .expect("fixture entry");
+    let password = entry["secrets"]["masterPassword"]
+        .as_str()
+        .expect("master password");
+    let recovery_kit = entry["secrets"]["recoveryKit"]
+        .as_str()
+        .expect("recovery kit");
+    let source_bytes = fixture_bytes(file_name);
+    let directory = TestDirectory::new();
+    let source = directory.0.join(file_name);
+    let destination = directory.0.join("active.sesame");
+    fs::write(&source, source_bytes).expect("source fixture");
+    fs::write(&destination, ACTIVE).expect("active vault");
+
+    let source_file = VaultLoader::parse(source_bytes).expect("source envelope");
+    let source_payload =
+        VaultLoader::authenticate(&source_file, Credential::MasterPassword(password))
+            .expect("source authentication");
+    let source_value: serde_json::Value =
+        serde_json::from_slice(source_payload.bytes()).expect("source payload");
+    let prepared =
+        prepare_backup_for_restore(&source, &destination, password).expect("prepared transaction");
+    assert_eq!(fs::read(&source).expect("source preserved"), source_bytes);
+    let installed = apply_restored_vault_file(&destination, &prepared).expect("installed restore");
+    assert_eq!(
+        fs::read(&source).expect("source still preserved"),
+        source_bytes
+    );
+    let safety = directory
+        .0
+        .join("backups")
+        .join(installed.safety_backup_name.expect("safety backup"));
+    assert_eq!(fs::read(safety).expect("safety bytes"), ACTIVE);
+
+    let restarted_file = VaultLoader::read(&destination).expect("restart read");
+    assert_eq!(restarted_file.format_version, VAULT_FORMAT_VERSION);
+    let restarted = VaultLoader::open(&restarted_file, Credential::MasterPassword(password))
+        .expect("restart password open");
+    assert!(!restarted.migration.required());
+    let restarted_payload = serialize_payload(&restarted.payload).expect("restarted payload");
+    assert_manifest_payload(entry, &restarted.payload);
+    assert_original_fields_preserved(entry, &source_value, &restarted_payload);
+    let recovered = VaultLoader::open(&restarted_file, Credential::RecoveryKit(recovery_kit))
+        .expect("restart recovery open");
+    assert_eq!(
+        serialize_payload(&recovered.payload).expect("recovery payload"),
+        restarted_payload
+    );
+
+    let new_backup = directory.0.join("new-backup.sesame");
+    fs::copy(&destination, &new_backup).expect("new backup");
+    let backup_file = VaultLoader::read(&new_backup).expect("backup read");
+    let backup =
+        VaultLoader::open(&backup_file, Credential::MasterPassword(password)).expect("backup open");
+    assert!(!backup.migration.required());
+    assert_eq!(
+        serialize_payload(&backup.payload).expect("backup payload"),
+        restarted_payload
+    );
+
+    let second_destination = directory.0.join("restored-again.sesame");
+    let prepared_again = prepare_backup_for_restore(&new_backup, &second_destination, password)
+        .expect("idempotent preparation");
+    apply_restored_vault_file(&second_destination, &prepared_again).expect("idempotent install");
+    let opened_again = VaultLoader::open(
+        &VaultLoader::read(&second_destination).expect("second read"),
+        Credential::RecoveryKit(recovery_kit),
+    )
+    .expect("second recovery open");
+    assert!(!opened_again.migration.required());
+    assert_eq!(
+        serialize_payload(&opened_again.payload).expect("second payload"),
+        restarted_payload
+    );
+    let replayed = prepare_backup_for_restore(&new_backup, &second_destination, password)
+        .expect("replayed preparation");
+    apply_restored_vault_file(&second_destination, &replayed).expect("replayed install");
+    let replayed = VaultLoader::open(
+        &VaultLoader::read(&second_destination).expect("replayed read"),
+        Credential::MasterPassword(password),
+    )
+    .expect("replayed open");
+    assert_eq!(
+        serialize_payload(&replayed.payload).expect("replayed payload"),
+        restarted_payload
+    );
+}
+
+macro_rules! restore_test {
+    ($name:ident, $fixture:literal) => {
+        #[test]
+        fn $name() {
+            restore_fixture($fixture);
+        }
+    };
+}
+
+restore_test!(fixture_v0_1_0_restores_transactionally, "v0.1.0.sesame");
+restore_test!(fixture_v0_1_1_restores_transactionally, "v0.1.1.sesame");
+restore_test!(fixture_v0_2_0_restores_transactionally, "v0.2.0.sesame");
+restore_test!(fixture_v0_2_1_restores_transactionally, "v0.2.1.sesame");
+restore_test!(fixture_v0_2_2_restores_transactionally, "v0.2.2.sesame");
+
+fn assert_original_fields_preserved(
+    entry: &serde_json::Value,
+    source: &serde_json::Value,
+    restored: &[u8],
+) {
+    let mut source = source.clone();
+    let mut restored: serde_json::Value = serde_json::from_slice(restored).expect("restored value");
+    assert_stored_timestamps(&source, &restored);
+    for (id, fields) in entry["expectedMigration"]["backfilled"]
+        .as_object()
+        .expect("backfilled records")
+    {
+        let fields: Vec<&str> = fields
+            .as_array()
+            .expect("backfilled field list")
+            .iter()
+            .map(|field| field.as_str().expect("backfilled field"))
+            .collect();
+        remove_fields_for_id(&mut source, id, &fields);
+        remove_fields_for_id(&mut restored, id, &fields);
+    }
+    retain_source_shape(&source, &mut restored);
+    assert_eq!(restored, source);
+}
+
+fn remove_fields_for_id(value: &mut serde_json::Value, id: &str, fields: &[&str]) {
+    match value {
+        serde_json::Value::Object(object) => {
+            if object.get("id").and_then(serde_json::Value::as_str) == Some(id) {
+                for field in fields {
+                    object.remove(*field);
+                }
+            }
+            for value in object.values_mut() {
+                remove_fields_for_id(value, id, fields);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                remove_fields_for_id(value, id, fields);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_stored_timestamps(source: &serde_json::Value, restored: &serde_json::Value) {
+    match (source, restored) {
+        (serde_json::Value::Object(source), serde_json::Value::Object(restored)) => {
+            for key in [
+                "createdAt",
+                "updatedAt",
+                "passwordUpdatedAt",
+                "deletedAt",
+                "capturedAt",
+            ] {
+                if let Some(value) = source.get(key).filter(|value| value.as_u64() != Some(0)) {
+                    assert_eq!(restored.get(key), Some(value));
+                }
+            }
+            for (key, value) in source {
+                if let Some(restored) = restored.get(key) {
+                    assert_stored_timestamps(value, restored);
+                }
+            }
+        }
+        (serde_json::Value::Array(source), serde_json::Value::Array(restored)) => {
+            assert_eq!(source.len(), restored.len());
+            for (source, restored) in source.iter().zip(restored) {
+                assert_stored_timestamps(source, restored);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn retain_source_shape(source: &serde_json::Value, migrated: &mut serde_json::Value) {
+    match (source, migrated) {
+        (serde_json::Value::Object(source), serde_json::Value::Object(migrated)) => {
+            migrated.retain(|key, _| source.contains_key(key));
+            for (key, value) in source {
+                if let Some(migrated) = migrated.get_mut(key) {
+                    retain_source_shape(value, migrated);
+                }
+            }
+        }
+        (serde_json::Value::Array(source), serde_json::Value::Array(migrated)) => {
+            assert_eq!(source.len(), migrated.len());
+            for (source, migrated) in source.iter().zip(migrated) {
+                retain_source_shape(source, migrated);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_manifest_payload(entry: &serde_json::Value, payload: &sesame_core::VaultPayload) {
+    assert_eq!(
+        payload.vault_name,
+        entry["vault"]["name"].as_str().expect("vault name")
+    );
+    assert_eq!(
+        payload.vault_id.as_deref(),
+        entry["vault"]["vaultId"].as_str()
+    );
+    assert_eq!(
+        payload.revision,
+        entry["vault"]["revision"].as_u64().expect("vault revision")
+    );
+    for (name, actual) in [
+        ("entries", payload.entries.len()),
+        ("identities", payload.identities.len()),
+        ("secureNotes", payload.secure_notes.len()),
+        ("cards", payload.cards.len()),
+        ("wifiNetworks", payload.wifi_networks.len()),
+        ("sshKeys", payload.ssh_keys.len()),
+        ("softwareLicenses", payload.software_licenses.len()),
+        ("documents", payload.documents.len()),
+        ("customRecords", payload.custom_records.len()),
+        ("folders", payload.folders.len()),
+        ("trash", payload.trash.len()),
+        ("history", payload.history.len()),
+    ] {
+        assert_eq!(
+            actual,
+            entry["expectedMigration"]["afterOpenCounts"][name]
+                .as_u64()
+                .expect("expected count") as usize,
+            "{name} count"
+        );
+    }
+    let items = payload.item_views();
+    let present_ids: Vec<&str> = items
+        .iter()
+        .map(|item| item.id())
+        .chain(payload.folders.iter().map(|folder| folder.id.as_str()))
+        .chain(payload.history.iter().map(|history| history.id.as_str()))
+        .chain(payload.trash.iter().map(|trash| trash.item.id()))
+        .collect();
+    for expected in entry["stableIds"].as_array().expect("stable ids") {
+        let expected = expected.as_str().expect("stable id");
+        assert!(
+            present_ids.contains(&expected),
+            "missing stable id {expected}"
+        );
+    }
+    let preserved = &entry["expectedMigration"]["preservedTimestamps"]["login-alpha"];
+    let preserved_login = payload
+        .entries
+        .iter()
+        .find(|item| item.id == "login-alpha")
+        .expect("preserved login");
+    assert_eq!(
+        preserved_login.created_at,
+        preserved["createdAt"].as_u64().expect("created time")
+    );
+    assert_eq!(
+        preserved_login.updated_at,
+        preserved["updatedAt"].as_u64().expect("updated time")
+    );
+    assert_eq!(
+        preserved_login.password_updated_at,
+        preserved["passwordUpdatedAt"]
+            .as_u64()
+            .expect("password time")
+    );
+    let backfilled = payload
+        .entries
+        .iter()
+        .find(|item| item.id == "login-empty")
+        .expect("backfilled login");
+    let fields = entry["expectedMigration"]["backfilled"]["login-empty"]
+        .as_array()
+        .expect("backfilled fields");
+    assert!(fields.iter().any(|field| field == "createdAt"));
+    assert!(fields.iter().any(|field| field == "updatedAt"));
+    assert!(fields.iter().any(|field| field == "passwordUpdatedAt"));
+    assert!(fields.iter().any(|field| field == "revision"));
+    assert!(backfilled.created_at > 0);
+    assert_eq!(backfilled.updated_at, backfilled.created_at);
+    assert_eq!(backfilled.password_updated_at, backfilled.updated_at);
+    assert_eq!(backfilled.revision, 1);
+}
+
+fn fixture_bytes(file_name: &str) -> &'static [u8] {
+    match file_name {
+        "v0.1.0.sesame" => include_bytes!("fixtures/compatibility/v0.1.0.sesame"),
+        "v0.1.1.sesame" => include_bytes!("fixtures/compatibility/v0.1.1.sesame"),
+        "v0.2.0.sesame" => include_bytes!("fixtures/compatibility/v0.2.0.sesame"),
+        "v0.2.1.sesame" => include_bytes!("fixtures/compatibility/v0.2.1.sesame"),
+        "v0.2.2.sesame" => include_bytes!("fixtures/compatibility/v0.2.2.sesame"),
+        _ => panic!("unknown fixture"),
+    }
+}

--- a/src-tauri/sesame-core/tests/vault_loader.rs
+++ b/src-tauri/sesame-core/tests/vault_loader.rs
@@ -1,0 +1,245 @@
+use std::{fs, path::PathBuf};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use sesame_core::{
+    api, backup, encrypt_bytes,
+    loader::{Credential, FormatState, LoadFailure, VaultLoader},
+    payload_aad_for_file, random_id, CipherBlob, VaultFile, MAX_VAULT_FILE_BYTES,
+};
+
+const PASSWORD: &str = "fictional master password 01";
+const FIXTURE: &[u8] = include_bytes!("fixtures/compatibility/v0.2.2.sesame");
+
+fn fixture() -> VaultFile {
+    VaultLoader::parse(FIXTURE).expect("fixture envelope")
+}
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!("sesame-loader-{}", random_id()));
+        fs::create_dir(&path).expect("test directory");
+        Self(path)
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn format_one_is_rejected_consistently_before_credentials_or_replacement() {
+    let mut file = fixture();
+    file.format_version = 1;
+    let bytes = serde_json::to_vec(&file).expect("envelope");
+    let expected = LoadFailure::UnsupportedFormat { format: 1 };
+    assert_eq!(VaultLoader::inspect(&bytes), Err(expected));
+    assert_eq!(VaultLoader::parse(&bytes).err(), Some(expected));
+    assert_eq!(
+        VaultLoader::open(&file, Credential::MasterPassword("wrong")).err(),
+        Some(expected)
+    );
+    assert_eq!(
+        VaultLoader::open(&file, Credential::RecoveryKit("wrong")).err(),
+        Some(expected)
+    );
+    assert_eq!(
+        VaultLoader::open(&file, Credential::VaultKey(&[0; 32])).err(),
+        Some(expected)
+    );
+
+    let directory = TestDirectory::new();
+    let source = directory.0.join("source.sesame");
+    let destination = directory.0.join("active.sesame");
+    fs::write(&source, &bytes).expect("source");
+    fs::write(&destination, FIXTURE).expect("active");
+    assert_eq!(
+        backup::read_backup_file(&source).err(),
+        Some(expected.to_string())
+    );
+    assert_eq!(
+        backup::verify_backup_file(&source, PASSWORD).err(),
+        Some(expected.to_string())
+    );
+    assert_eq!(
+        backup::prepare_backup_for_restore(&source, &destination, PASSWORD).err(),
+        Some(expected.to_string())
+    );
+    assert_eq!(
+        api::open_vault_bytes(&bytes, PASSWORD).err(),
+        Some(expected.to_string())
+    );
+    assert_eq!(fs::read(source).expect("source preserved"), bytes);
+    assert_eq!(fs::read(destination).expect("active preserved"), FIXTURE);
+    assert_eq!(fs::read_dir(&directory.0).expect("directory").count(), 2);
+}
+
+#[test]
+fn inspection_reports_migration_without_authenticating_or_guessing_labels() {
+    let current = VaultLoader::inspect(FIXTURE).expect("inspection");
+    assert_eq!(current.state, FormatState::Current);
+    for format in 2..=9 {
+        let mut file = fixture();
+        file.format_version = format;
+        let bytes = serde_json::to_vec(&file).expect("relabelled envelope");
+        let inspected = VaultLoader::inspect(&bytes).expect("recognized envelope only");
+        assert_eq!(inspected.format, format);
+        assert_eq!(inspected.state, FormatState::NeedsMigration);
+        assert_eq!(
+            VaultLoader::open(&file, Credential::MasterPassword(PASSWORD)).err(),
+            Some(LoadFailure::Authentication)
+        );
+    }
+    let mut file = fixture();
+    file.setup_complete = false;
+    assert_eq!(
+        VaultLoader::open(&file, Credential::MasterPassword(PASSWORD)).err(),
+        Some(LoadFailure::Authentication)
+    );
+}
+
+#[test]
+fn failures_distinguish_credentials_ciphertext_and_authenticated_schema() {
+    let mut file = fixture();
+    assert_eq!(
+        VaultLoader::open(&file, Credential::MasterPassword("wrong")).err(),
+        Some(LoadFailure::WrongPassword)
+    );
+    assert_eq!(
+        VaultLoader::open(&file, Credential::RecoveryKit("wrong")).err(),
+        Some(LoadFailure::WrongRecoveryKit)
+    );
+    let key = VaultLoader::unwrap_key(&file, Credential::MasterPassword(PASSWORD)).expect("key");
+    let aad = payload_aad_for_file(file.format_version, file.setup_complete).expect("label");
+    file.payload = encrypt_bytes(&key, br#"{"items":[{"kind":"future-record"}]}"#, aad)
+        .expect("authenticated schema");
+    assert_eq!(
+        VaultLoader::open(&file, Credential::VaultKey(&key)).err(),
+        Some(LoadFailure::RecoveryRequired { format: 10 })
+    );
+    let mut ciphertext = URL_SAFE_NO_PAD
+        .decode(&file.payload.ciphertext)
+        .expect("ciphertext");
+    ciphertext[0] ^= 1;
+    file.payload.ciphertext = URL_SAFE_NO_PAD.encode(ciphertext);
+    assert_eq!(
+        VaultLoader::open(&file, Credential::VaultKey(&key)).err(),
+        Some(LoadFailure::Authentication)
+    );
+}
+
+#[test]
+fn envelope_failures_are_bounded_and_do_not_become_wrong_password() {
+    let mut file = fixture();
+    file.format_version = 11;
+    assert_eq!(
+        VaultLoader::validate(&file),
+        Err(LoadFailure::NewerFormat { format: 11 })
+    );
+    file = fixture();
+    file.kdf.memory_kib = u32::MAX;
+    assert_eq!(
+        VaultLoader::open(&file, Credential::MasterPassword("wrong")).err(),
+        Some(LoadFailure::UnsafeKdf)
+    );
+    file = fixture();
+    file.kdf.memory_kib = 1;
+    assert_eq!(VaultLoader::validate(&file), Err(LoadFailure::UnsafeKdf));
+    file = fixture();
+    file.recovery_wrap = None;
+    assert_eq!(
+        VaultLoader::validate(&file),
+        Err(LoadFailure::InvalidStructure)
+    );
+    file = fixture();
+    file.payload.nonce = "!".into();
+    assert_eq!(
+        VaultLoader::validate(&file),
+        Err(LoadFailure::InvalidStructure)
+    );
+    assert_eq!(
+        VaultLoader::inspect(b"{"),
+        Err(LoadFailure::InvalidStructure)
+    );
+    assert_eq!(
+        VaultLoader::inspect(&vec![b' '; MAX_VAULT_FILE_BYTES as usize + 1]),
+        Err(LoadFailure::SizeLimit)
+    );
+    let directory = TestDirectory::new();
+    assert_eq!(
+        VaultLoader::read(&directory.0.join("missing.sesame")).err(),
+        Some(LoadFailure::LocalIo)
+    );
+    let path = directory.0.join("oversized.sesame");
+    fs::File::create(&path)
+        .expect("sparse file")
+        .set_len(MAX_VAULT_FILE_BYTES + 1)
+        .expect("sparse length");
+    assert_eq!(VaultLoader::read(&path).err(), Some(LoadFailure::SizeLimit));
+}
+
+#[test]
+fn named_password_path_does_not_accept_a_recovery_kit() {
+    let manifest: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/compatibility/manifest.json"))
+            .expect("manifest");
+    let kit = manifest["fixtures"][4]["secrets"]["recoveryKit"]
+        .as_str()
+        .expect("fictional kit");
+    assert_eq!(
+        VaultLoader::load(FIXTURE, Credential::MasterPassword(kit)).err(),
+        Some(LoadFailure::WrongPassword)
+    );
+    assert!(VaultLoader::load(FIXTURE, Credential::RecoveryKit(kit)).is_ok());
+}
+
+#[test]
+fn migration_is_in_memory_and_resealed_result_is_idempotent() {
+    let opened = VaultLoader::load(FIXTURE, Credential::MasterPassword(PASSWORD)).expect("open");
+    assert!(opened.migration.payload_changed);
+    assert!(!opened.migration.envelope_changed);
+    assert_eq!(opened.migration.source_format, 10);
+    let sealed = api::seal_vault(&opened).expect("seal");
+    let reopened =
+        VaultLoader::open(&sealed, Credential::MasterPassword(PASSWORD)).expect("reopen");
+    assert!(!reopened.migration.required());
+    assert_eq!(opened.payload.entries.len(), reopened.payload.entries.len());
+    assert_eq!(
+        serde_json::to_vec(&fixture()).expect("unchanged envelope"),
+        serde_json::to_vec(&opened.file).expect("read-only open")
+    );
+}
+
+#[test]
+fn snapshots_use_only_the_supplied_protocol_context_and_preserve_authenticated_bytes() {
+    let authenticated = VaultLoader::authenticate(&fixture(), Credential::MasterPassword(PASSWORD))
+        .expect("fixture");
+    let key = [17; 32];
+    let aad = b"fictional signed snapshot context";
+    let blob = encrypt_bytes(&key, authenticated.bytes(), aad).expect("snapshot");
+    let snapshot = VaultLoader::open_snapshot(2, &key, &blob, aad).expect("snapshot");
+    assert_eq!(snapshot.bytes(), authenticated.bytes());
+    assert_eq!(
+        snapshot.payload().vault_id,
+        authenticated.payload().vault_id
+    );
+    assert_eq!(
+        VaultLoader::open_snapshot(2, &key, &blob, b"stale context").err(),
+        Some(LoadFailure::Authentication)
+    );
+    assert_eq!(
+        VaultLoader::open_snapshot(3, &key, &blob, aad).err(),
+        Some(LoadFailure::InvalidStructure)
+    );
+    let malformed = CipherBlob {
+        nonce: "?".into(),
+        ciphertext: blob.ciphertext,
+    };
+    assert_eq!(
+        VaultLoader::open_snapshot(2, &key, &malformed, aad).err(),
+        Some(LoadFailure::InvalidStructure)
+    );
+}

--- a/src-tauri/src/commands/backups.rs
+++ b/src-tauri/src/commands/backups.rs
@@ -297,24 +297,21 @@ pub fn restore_backup(
     // Authenticate before invalidating anything: a failure must not lock the user out.
     let prepared = prepare_backup_for_restore(&source, &destination, &secret);
     secret.zeroize();
-    let file = prepared?;
+    let prepared = prepared?;
 
-    // Guard held through replacement so a concurrent save cannot overwrite it.
-    let session = state.begin_destructive_lifecycle_change()?;
-    let outcome = apply_restored_vault_file(&destination, &file);
-    drop(session);
-    let (safety_backup_name, pin_unlock_available, hello_unlock_available) = outcome?;
-    state.cache_pin_unlock(pin_unlock_available);
-    state.cache_hello_unlock(hello_unlock_available);
-    if pin_unlock_available {
+    let installed =
+        state.apply_lifecycle_replacement(|| apply_restored_vault_file(&destination, &prepared))?;
+    state.cache_pin_unlock(installed.pin_unlock_available);
+    state.cache_hello_unlock(installed.hello_unlock_available);
+    if installed.pin_unlock_available {
         let _ = establish_pin_throttle_state(&app, &state);
     } else {
         discard_pin_throttle_state(&app, &state);
     }
     Ok(RestoreBackupResult {
-        safety_backup_name,
-        pin_unlock_available,
-        hello_unlock_available,
+        safety_backup_name: installed.safety_backup_name,
+        pin_unlock_available: installed.pin_unlock_available,
+        hello_unlock_available: installed.hello_unlock_available,
     })
 }
 

--- a/src-tauri/src/commands/backups.rs
+++ b/src-tauri/src/commands/backups.rs
@@ -12,11 +12,11 @@ use crate::vault::backup::{
 };
 use crate::vault::platform::{copy_private_file, create_private_dir, securely_delete};
 use crate::vault::recovery_health;
-use crate::vault::storage::{check_supported_vault_format, vault_path, write_export_file};
+use crate::vault::storage::{vault_path, write_export_file};
 use crate::vault::util::{backup_file_name, random_id, unix_timestamp};
 use crate::vault::{
-    BackupInspection, BackupVerification, RestoreBackupRequest, RestoreBackupResult, VaultFile,
-    VaultResult, VaultState, MAX_VAULT_FILE_BYTES,
+    BackupInspection, BackupVerification, RestoreBackupRequest, RestoreBackupResult, VaultResult,
+    VaultState,
 };
 
 #[tauri::command]
@@ -189,15 +189,7 @@ pub fn delete_local_vault(
     // unattended unlocked window cannot destroy the vault and its backups, and so
     // a locked window cannot either.
     let master_password = Zeroizing::new(master_password);
-    let bytes = crate::vault::util::require_file_with_limit(
-        &vault,
-        MAX_VAULT_FILE_BYTES,
-        "Sesame could not find a local vault to remove.",
-    )?;
-    let file: VaultFile = serde_json::from_slice(&bytes).map_err(|_| {
-        "This vault file is not valid. Restore a known-good encrypted backup.".to_string()
-    })?;
-    check_supported_vault_format(&file)?;
+    let file = sesame_core::loader::VaultLoader::read(&vault)?;
     let mut key =
         sesame_core::api::unwrap_key_with_password(&file, &master_password).map_err(|_| {
             "That master password is not correct. The vault was not removed.".to_string()

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -6,11 +6,11 @@ use zeroize::{Zeroize, Zeroizing};
 
 use crate::vault::crypto::decrypt_bytes;
 use crate::vault::storage::{
-    check_supported_vault_format, clear_pin_throttle_state, complete_recovery_setup_for_session,
-    derive_pin_wrapping_key, persist_session, read_pin_throttle_state, remove_hello_for_session,
-    remove_pin_for_session, resume_recovery_setup_for_session, set_hello_for_session,
-    set_pin_for_session, validate_new_unlock_pin, validate_unlock_pin, vault_path,
-    write_pin_throttle_state, write_vault_file,
+    clear_pin_throttle_state, complete_recovery_setup_for_session, derive_pin_wrapping_key,
+    persist_session, read_pin_throttle_state, remove_hello_for_session, remove_pin_for_session,
+    resume_recovery_setup_for_session, set_hello_for_session, set_pin_for_session,
+    validate_new_unlock_pin, validate_unlock_pin, vault_path, write_pin_throttle_state,
+    write_vault_file,
 };
 use crate::vault::util::random_id;
 use crate::vault::windows_hello;
@@ -217,15 +217,7 @@ pub fn unlock_recovery_vault(
         .lock()
         .map_err(|_| "Sesame could not open the vault session.".to_string())?;
     let path = vault_path(&app)?;
-    let bytes = crate::vault::util::require_file_with_limit(
-        &path,
-        MAX_VAULT_FILE_BYTES,
-        "Sesame could not find a local vault to unlock.",
-    )?;
-    let file: VaultFile = serde_json::from_slice(&bytes).map_err(|_| {
-        "This vault file is not valid. Restore a known-good encrypted backup.".to_string()
-    })?;
-    check_supported_vault_format(&file)?;
+    let file = sesame_core::loader::VaultLoader::read(&path)?;
     let supplied_kit = Zeroizing::new(request.recovery_kit);
     let key_array = sesame_core::api::unwrap_key_with_recovery_kit(&file, &supplied_kit)?;
     install_unlocked_session(&state, &mut session, path, key_array, file)
@@ -320,15 +312,7 @@ pub fn unlock_with_windows_hello(
         .lock()
         .map_err(|_| "Sesame could not open the vault session.".to_string())?;
     let path = vault_path(&app)?;
-    let bytes = crate::vault::util::require_file_with_limit(
-        &path,
-        MAX_VAULT_FILE_BYTES,
-        "Sesame could not find a local vault to unlock.",
-    )?;
-    let file: VaultFile = serde_json::from_slice(&bytes).map_err(|_| {
-        "This vault file is not valid. Restore a known-good encrypted backup.".to_string()
-    })?;
-    check_supported_vault_format(&file)?;
+    let file = sesame_core::loader::VaultLoader::read(&path)?;
     let wrap = file
         .hello_wrap
         .as_ref()
@@ -392,15 +376,7 @@ fn unlock_pin_vault_inner(
         .lock()
         .map_err(|_| "Sesame could not open the vault session.".to_string())?;
     let path = vault_path(&app)?;
-    let bytes = crate::vault::util::require_file_with_limit(
-        &path,
-        MAX_VAULT_FILE_BYTES,
-        "Sesame could not find a local vault to unlock.",
-    )?;
-    let file: VaultFile = serde_json::from_slice(&bytes).map_err(|_| {
-        "This vault file is not valid. Restore a known-good encrypted backup.".to_string()
-    })?;
-    check_supported_vault_format(&file)?;
+    let file = sesame_core::loader::VaultLoader::read(&path)?;
     let pin_wrap = file
         .pin_wrap
         .as_ref()
@@ -476,15 +452,7 @@ pub fn unlock_vault(
         .lock()
         .map_err(|_| "Sesame could not open the vault session.".to_string())?;
     let path = vault_path(&app)?;
-    let bytes = crate::vault::util::require_file_with_limit(
-        &path,
-        MAX_VAULT_FILE_BYTES,
-        "Sesame could not find a local vault to unlock.",
-    )?;
-    let file: VaultFile = serde_json::from_slice(&bytes).map_err(|_| {
-        "This vault file is not valid. Restore a known-good encrypted backup.".to_string()
-    })?;
-    check_supported_vault_format(&file)?;
+    let file = sesame_core::loader::VaultLoader::read(&path)?;
     let master_password = Zeroizing::new(request.master_password);
     let key_array = sesame_core::api::unwrap_key_with_password(&file, &master_password)?;
     let result = install_unlocked_session(&state, &mut session, path, key_array, file);

--- a/src-tauri/src/commands/sync_adopt.rs
+++ b/src-tauri/src/commands/sync_adopt.rs
@@ -95,10 +95,13 @@ pub async fn sync_adopt_vault(
         nonce: envelope.nonce.clone(),
         ciphertext: envelope.ciphertext.clone(),
     };
-    let mut plaintext = decrypt_bytes(&key, &blob, &snapshot_aad_for(&envelope))?;
-    let payload: crate::vault::types::VaultPayload = serde_json::from_slice(&plaintext)
-        .map_err(|_| "The synced vault could not be read.".to_string())?;
-    plaintext.zeroize();
+    let authenticated = sesame_core::loader::VaultLoader::open_snapshot(
+        envelope.version,
+        &key,
+        &blob,
+        &snapshot_aad_for(&envelope),
+    )?;
+    let payload = authenticated.payload().clone();
     let entry_count = payload.entries.len();
 
     let recovery_kit = {

--- a/src-tauri/src/commands/sync_transfer.rs
+++ b/src-tauri/src/commands/sync_transfer.rs
@@ -249,13 +249,18 @@ pub async fn sync_download_vault(
             );
         }
 
-        let plaintext = vault.expose_vault_key(|key| {
-            crate::vault::crypto::decrypt_bytes(key, &blob, &snapshot_aad_for(&envelope))
+        let authenticated = vault.expose_vault_key(|key| {
+            sesame_core::loader::VaultLoader::open_snapshot(
+                envelope.version,
+                key,
+                &blob,
+                &snapshot_aad_for(&envelope),
+            )
+            .map_err(Into::into)
         })?;
-        let payload: crate::vault::types::VaultPayload = serde_json::from_slice(&plaintext)
-            .map_err(|_| "The synced vault could not be read.".to_string())?;
+        let payload = authenticated.payload().clone();
         let count = payload.entries.len();
-        let digest = crate::sync::state::payload_digest(&plaintext);
+        let digest = crate::sync::state::payload_digest(authenticated.bytes());
         crate::vault::storage::commit_payload_change(vault, payload)?;
         // Session epoch bumps before the lock releases: approvals must not release stale credentials.
         state.advance_session_epoch();
@@ -592,8 +597,7 @@ pub async fn sync_conflict_details(
     let vault = session.as_ref().ok_or("Unlock Sesame before syncing.")?;
     let local_payload = vault.open_payload()?;
     let remote = vault.expose_vault_key(|key| decrypt_snapshot(key, &envelope))?;
-    let remote_payload: crate::vault::types::VaultPayload = serde_json::from_slice(&remote)
-        .map_err(|_| "The synced vault could not be read.".to_string())?;
+    let remote_payload = remote.payload();
 
     Ok(SyncConflictView {
         this_device: SyncConflictSideView {
@@ -660,8 +664,7 @@ pub async fn sync_resolve_conflict(
         let local = serde_json::to_vec(&*local_payload)
             .map_err(|_| "Sesame could not read the local vault.".to_string())?;
         let remote = vault.expose_vault_key(|key| decrypt_snapshot(key, &envelope))?;
-        let remote_payload: crate::vault::types::VaultPayload = serde_json::from_slice(&remote)
-            .map_err(|_| "The synced vault could not be read.".to_string())?;
+        let remote_payload = remote.payload();
         let remote_entries = remote_payload.entries.len();
         let local_entries = local_payload.entries.len();
 
@@ -672,12 +675,12 @@ pub async fn sync_resolve_conflict(
             (
                 crate::sync::conflict_backup::Side::ThisDevice,
                 base_revision,
-                &local,
+                local.as_slice(),
             ),
             (
                 crate::sync::conflict_backup::Side::OtherDevice,
                 current.revision,
-                &remote,
+                remote.bytes(),
             ),
         ] {
             let path = crate::sync::conflict_backup::write_verified(
@@ -763,8 +766,7 @@ pub async fn sync_resolve_conflict(
         });
     }
 
-    let payload: crate::vault::types::VaultPayload = serde_json::from_slice(&remote_plaintext)
-        .map_err(|_| "The synced vault could not be read.".to_string())?;
+    let payload = remote_plaintext.payload().clone();
     {
         let mut session = state
             .session
@@ -782,7 +784,7 @@ pub async fn sync_resolve_conflict(
             &current.vault_id,
             current.revision,
             current.vault_epoch,
-            &remote_plaintext,
+            remote_plaintext.bytes(),
         )
         .with_head(&crate::sync::envelope::digest(&envelope), &current.receipt),
     )?;
@@ -811,12 +813,18 @@ fn confirm_unchanged(vault: &crate::vault::UnlockedVault, captured: &str) -> Res
 fn decrypt_snapshot(
     key: &[u8; 32],
     envelope: &crate::sync::envelope::Envelope,
-) -> VaultResult<Vec<u8>> {
+) -> VaultResult<sesame_core::loader::AuthenticatedPayload> {
     let blob = crate::vault::types::CipherBlob {
         nonce: envelope.nonce.clone(),
         ciphertext: envelope.ciphertext.clone(),
     };
-    crate::vault::crypto::decrypt_bytes(key, &blob, &snapshot_aad_for(envelope))
+    sesame_core::loader::VaultLoader::open_snapshot(
+        envelope.version,
+        key,
+        &blob,
+        &snapshot_aad_for(envelope),
+    )
+    .map_err(Into::into)
 }
 
 fn backup_stamp() -> String {

--- a/src-tauri/src/commands/sync_transfer_recovery.rs
+++ b/src-tauri/src/commands/sync_transfer_recovery.rs
@@ -17,7 +17,7 @@ pub async fn sync_restore_conflict_backup(app: AppHandle, state: tauri::State<'_
     let mut session = state.session.lock().map_err(|_| "Sesame could not read the unlocked vault.".to_string())?;
     let vault = session.as_mut().ok_or("Unlock Sesame before restoring a recovery copy.")?;
     let contents = vault.expose_vault_key(|key| crate::sync::conflict_backup::read_verified(&path, key))?;
-    let payload: crate::vault::types::VaultPayload = serde_json::from_slice(&contents.payload).map_err(|_| "That recovery copy could not be read.".to_string())?;
+    let payload = contents.payload.payload().clone();
     let entry_count = payload.entries.len();
     let current = vault.open_payload()?;
     let current_payload = serde_json::to_vec(&*current).map_err(|_| "Sesame could not read the local vault.".to_string())?;

--- a/src-tauri/src/sync/conflict_backup.rs
+++ b/src-tauri/src/sync/conflict_backup.rs
@@ -6,11 +6,9 @@ use std::path::{Path, PathBuf};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 
-use crate::vault::crypto::{decrypt_bytes, encrypt_bytes};
-use crate::vault::types::VaultPayload;
-use crate::vault::{
-    payload_aad_for_file, UnlockedVault, VaultFile, VaultResult, PAYLOAD_AAD, VAULT_FORMAT_VERSION,
-};
+use crate::vault::crypto::encrypt_bytes;
+use crate::vault::{UnlockedVault, VaultFile, VaultResult, PAYLOAD_AAD, VAULT_FORMAT_VERSION};
+use sesame_core::loader::{AuthenticatedPayload, Credential, VaultLoader};
 
 pub const BACKUP_DIR_NAME: &str = "sync-conflict-backups";
 
@@ -68,7 +66,7 @@ pub fn write_verified(
     let path = create_new_file(directory, side, revision, stamp, &body)?;
 
     let recovered = vault.expose_vault_key(|key| read_verified(&path, key))?;
-    if recovered.payload != payload_bytes || recovered.revision != revision {
+    if recovered.payload.bytes() != payload_bytes || recovered.revision != revision {
         // Remove it rather than leave an artifact that claims to hold a vault it does not.
         let _ = std::fs::remove_file(&path);
         return Err("Sesame could not verify the recovery copy.".to_string());
@@ -117,20 +115,13 @@ fn create_new_file(
 pub struct RecoveredBackup {
     pub revision: i64,
     pub entry_count: usize,
-    pub payload: Vec<u8>,
+    pub payload: AuthenticatedPayload,
 }
 
 /// Fast-path read with the raw session key; the same file opens by master password or kit like any backup.
 pub fn read_verified(path: &Path, key: &[u8; 32]) -> VaultResult<RecoveredBackup> {
-    let body =
-        std::fs::read(path).map_err(|_| "Sesame could not read the recovery copy.".to_string())?;
-    let file: VaultFile = serde_json::from_slice(&body)
-        .map_err(|_| "That file is not a valid Sesame encrypted backup.".to_string())?;
-    let payload_aad = payload_aad_for_file(file.format_version, file.setup_complete)?;
-    let payload_bytes = decrypt_bytes(key, &file.payload, payload_aad)
-        .map_err(|_| "Sesame could not read the recovery copy.".to_string())?;
-    let payload: VaultPayload = serde_json::from_slice(&payload_bytes)
-        .map_err(|_| "Sesame could not read the recovery copy.".to_string())?;
+    let file = VaultLoader::read(path)?;
+    let payload = VaultLoader::authenticate(&file, Credential::VaultKey(key))?;
     let file_name = path
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
@@ -139,8 +130,8 @@ pub fn read_verified(path: &Path, key: &[u8; 32]) -> VaultResult<RecoveredBackup
         .ok_or("Sesame could not read the recovery copy.".to_string())?;
     Ok(RecoveredBackup {
         revision,
-        entry_count: payload.entries.len(),
-        payload: payload_bytes,
+        entry_count: payload.payload().entries.len(),
+        payload,
     })
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Sesame",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "app.usesesame.desktop",
   "build": {
     "beforeDevCommand": "npm run desktop:dev",

--- a/tools/vault-compatibility-contracts.test.mjs
+++ b/tools/vault-compatibility-contracts.test.mjs
@@ -53,6 +53,14 @@ test('the corpus records every published desktop release', () => {
   )
   for (const version of manifest.publishedVersions) {
     assert.match(version.commit, /^[0-9a-f]{40}$/)
+    assert.ok(Number.isFinite(Date.parse(version.publishedAt)))
+    assert.equal(version.releaseUrl, `https://github.com/usesesame/sesame-desktop/releases/tag/${version.tag}`)
+    assert.ok(version.packages.length > 0)
+    for (const asset of version.packages) {
+      assert.equal(asset.name, `Sesame_${version.tag.slice(1)}_x64-setup.exe`)
+      assert.match(asset.digest, /^sha256:[0-9a-f]{64}$/)
+      assert.ok(Number.isSafeInteger(asset.size) && asset.size > 0)
+    }
   }
 })
 
@@ -103,6 +111,17 @@ test('every fixture matches its recorded digest and is a genuine sealed envelope
     }
     assert.equal(envelope.formatVersion, fixture.formatVersion, fixture.fileName)
     assert.equal(envelope.setupComplete, fixture.setupComplete, fixture.fileName)
+    for (const params of [envelope.kdf, envelope.recoveryKdf]) {
+      for (const key of ['algorithm', 'memoryKib', 'iterations', 'parallelism']) {
+        assert.equal(params[key], fixture.kdf[key], `${fixture.fileName} ${key}`)
+        assert.equal(params[key], loadManifest().writerInventory.passwordAndRecoveryKdf[key])
+      }
+      assert.equal(Buffer.from(params.salt, 'base64url').length, 32, fixture.fileName)
+    }
+    assert.ok(envelope.recoveryWrap, fixture.fileName)
+    assert.equal(envelope.pinWrap, null, fixture.fileName)
+    assert.equal(envelope.helloWrap, null, fixture.fileName)
+    assert.equal(envelope.deviceWrap, undefined, fixture.fileName)
     const nonce = Buffer.from(envelope.keyWrap.nonce, 'base64url')
     const ciphertext = Buffer.from(envelope.keyWrap.ciphertext, 'base64url')
     assert.equal(nonce.length, 24, fixture.fileName)
@@ -127,6 +146,10 @@ test('formats without a recoverable writer stay recorded as unproven', () => {
   assert.ok(unproven.evidence.length > 0)
   assert.equal(unproven.decision.status, 'supportRetained')
   assert.ok(unproven.decision.note.length > 0)
+  assert.equal(unproven.recoveryPath.status, 'requiresHistoricalWriter')
+  assert.ok(unproven.recoveryPath.steps.length > 0)
+  assert.ok(unproven.recoveryPath.steps.every((step) => typeof step === 'string' && step.length > 0))
+  assert.ok(unproven.recoveryPath.limitation.length > 0)
 })
 
 test('each declared writer generation ships its generator driver', () => {


### PR DESCRIPTION
## Scope

- Area: build (release preparation)
- Linked issue: none
- Depends on: the vault compatibility commits already on main (da2d46e, 8fe7562, 3c188ee)

## What changed

Bumps the desktop version to 0.2.3 and adds the CHANGELOG section describing what the vault compatibility work means for a backup restore.

## Security and data boundary

- [x] This does not send vault contents, passwords, TOTP seeds, recovery data, or encryption keys to a Sesame service.
- [x] I reviewed changes to unlock, encryption, backup, import, browser messaging, authentication, or audit behaviour.
- [x] Any new logs and diagnostics are secret-safe.
- [ ] Not applicable; this change does not touch a security or data boundary.

This commit only carries version metadata and release notes. The vault boundary changes themselves are da2d46e, 8fe7562, and 3c188ee, validated in the vault program handoff.

## Validation

```text
npm run desktop:version:check   # passed
npm run desktop:contracts       # passed, 72 tests
npm run desktop:ci              # passed outside the sandbox for the vault code on 2026-09-05
```

## Evidence

The tag push triggers the release workflow, which runs npm run release:check on the tag.

## Review notes

- [x] Generated output and local state are not included.
- [x] Documentation matches the implemented state.
- [x] This change is safe to revert independently, or the dependency is documented above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Older vault backups are upgraded automatically to the current format during restore.
  - Recovery kits can be used to open and restore vaults.
  - Restore errors now distinguish incorrect passwords, damaged files, and unsupported newer vaults.

- **Bug Fixes**
  - Restores preserve the original vault until validation succeeds.
  - Failed or interrupted restores can roll back using a safety copy.
  - Improved compatibility and reliability across older vault versions.

- **Release**
  - Updated the application to version 0.2.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->