### PR TITLE
Prepare the 0.2.4 release

### DIFF
--- a/.github/workflows/release-early-access.yml
+++ b/.github/workflows/release-early-access.yml
@@ -155,6 +155,8 @@ jobs:
           $candidate = "release-artifacts/sesame-$($record.version)-windows-$($record.architecture).candidate.json"
           node tools/release-set-cli.mjs verify $candidate
           Copy-Item -LiteralPath $candidate -Destination release-handoff/
+          $env:SESAME_UPDATE_RECEIPT_V3_FILE = "release-artifacts/sesame-$($record.version)-windows-$($record.architecture).update-receipt.json"
+          if (-not (Test-Path -LiteralPath $env:SESAME_UPDATE_RECEIPT_V3_FILE)) { throw "The v3 update receipt was not produced: $($env:SESAME_UPDATE_RECEIPT_V3_FILE)." }
           node tools/create-static-update-manifest.mjs $candidate release-handoff/latest.json
 
       - name: Prepare and audit the public-only evidence set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Every released version has a section here. The release workflow reads the
 section matching the tag and puts it at the top of the GitHub release, so a
 release cannot be published without saying what changed in it.
 
+## 0.2.4
+
+- Updating from 0.1.1 through 0.2.2 to 0.2.3 failed with a receipt mismatch:
+  the 0.2.3 update receipt used a format those versions cannot verify. The
+  update manifest again carries the receipt format every released client
+  verifies, and the updater accepts both formats from this release on. Update
+  to 0.2.4 from any earlier release; an install already on 0.2.3 updates
+  manually once.
+
 ## 0.2.3
 
 - Restoring a backup from an older Sesame release now upgrades it to the current

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sesame",
   "private": true,
   "license": "AGPL-3.0-or-later",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "scripts": {
     "desktop:dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "sesame"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "arboard",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ glib = { path = "vendor/glib" }
 
 [package]
 name = "sesame"
-version = "0.2.3"
+version = "0.2.4"
 license = "AGPL-3.0-or-later"
 default-run = "sesame"
 description = "A calm, local-first password and recovery vault"

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -178,10 +178,6 @@ fn verify_candidate_receipt(
         .verify_strict(receipt.payload.as_bytes(), &signature)
         .map_err(|_| "Sesame rejected an update with an invalid release receipt.".to_string())?;
 
-    let claims: Vec<&str> = receipt.payload.split('\n').collect();
-    // Claim 11 is the download URL the publisher signed. Comparing it to the URL
-    // this manifest actually points at is what stops a tampered manifest from
-    // redirecting an otherwise genuine receipt at a different file.
     let manifest_url = manifest
         .get("url")
         .and_then(serde_json::Value::as_str)
@@ -191,8 +187,54 @@ fn verify_candidate_receipt(
         "linux" => "appimage",
         _ => "",
     };
+    let claims: Vec<&str> = receipt.payload.split('\n').collect();
+    match claims.first().copied() {
+        // Clients before 0.2.3 verify only the v3 receipt layout and 0.2.3
+        // verifies only the release-set layout, so both are accepted until the
+        // installed base is past the release that understands both.
+        Some("sesame-release-set-candidate-v1") => {
+            verify_set_candidate_claims(
+                &claims,
+                announced_version,
+                expected_platform,
+                expected_architecture,
+                expected_format,
+                manifest_url,
+                updater_signature,
+            )?;
+            Ok(claims[13].to_owned())
+        }
+        Some("sesame-release-candidate-v3") => {
+            verify_v3_candidate_claims(
+                &claims,
+                announced_version,
+                expected_platform,
+                expected_architecture,
+                manifest_url,
+                updater_signature,
+            )?;
+            Ok(claims[9].to_owned())
+        }
+        _ => Err(
+            "Sesame rejected an update whose manifest did not match its signed release receipt."
+                .into(),
+        ),
+    }
+}
+
+fn verify_set_candidate_claims(
+    claims: &[&str],
+    announced_version: &str,
+    expected_platform: &str,
+    expected_architecture: &str,
+    expected_format: &str,
+    manifest_url: &str,
+    updater_signature: &str,
+) -> VaultResult<()> {
+    // Claim 11 is the download URL the publisher signed. Comparing it to the URL
+    // this manifest actually points at is what stops a tampered manifest from
+    // redirecting an otherwise genuine receipt at a different file.
     if claims.len() != 17
-        || claims[0] != "sesame-release-set-candidate-v1"
         || claims[1] != announced_version
         || claims[3] != expected_platform
         || claims[4] != expected_architecture
@@ -216,7 +258,56 @@ fn verify_candidate_receipt(
                 .into(),
         );
     }
-    Ok(claims[13].to_owned())
+    Ok(())
+}
+
+fn verify_v3_candidate_claims(
+    claims: &[&str],
+    announced_version: &str,
+    expected_platform: &str,
+    expected_architecture: &str,
+    manifest_url: &str,
+    updater_signature: &str,
+) -> VaultResult<()> {
+    let expected_sigstore_identity = format!(
+        "https://github.com/usesesame/sesame-desktop/.github/workflows/release-early-access.yml@refs/tags/v{announced_version}"
+    );
+    // Claim 7 is the download URL the publisher signed. Comparing it to the URL
+    // this manifest actually points at is what stops a tampered manifest from
+    // redirecting an otherwise genuine receipt at a different file.
+    if claims.len() != 23
+        || claims[1] != announced_version
+        || claims[3] != expected_platform
+        || claims[4] != expected_architecture
+        || claims[7].is_empty()
+        || claims[7] != manifest_url
+        || claims[8].is_empty()
+        || !valid_sha256(claims[9])
+        || claims[10]
+            .parse::<u64>()
+            .ok()
+            .is_none_or(|bytes| bytes == 0)
+        || claims[11] != updater_signature
+        || claims[12].is_empty()
+        || (claims[13] != "early_access" && claims[13] != "production")
+        || claims[14] != "true"
+        || claims[15] != "https://token.actions.githubusercontent.com"
+        || claims[16] != expected_sigstore_identity
+        || !valid_sha256(claims[17])
+        || !valid_base64url_sha256(claims[18])
+        || (claims[19] != "true" && claims[19] != "false")
+        || (claims[13] == "early_access" && claims[19] != "false")
+        || (claims[13] == "production" && claims[19] != "true")
+        || (claims[19] == "true" && (claims[20].is_empty() || claims[21].is_empty()))
+        || (claims[19] == "true" && !valid_base64url_sha256(claims[22]))
+        || (claims[19] == "false" && !claims[22].is_empty())
+    {
+        return Err(
+            "Sesame rejected an update whose manifest did not match its signed release receipt."
+                .into(),
+        );
+    }
+    Ok(())
 }
 
 fn valid_sha256(value: &str) -> bool {
@@ -224,6 +315,12 @@ fn valid_sha256(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn valid_base64url_sha256(value: &str) -> bool {
+    URL_SAFE_NO_PAD
+        .decode(value)
+        .is_ok_and(|decoded| decoded.len() == 32)
 }
 
 #[cfg(test)]
@@ -318,5 +415,93 @@ mod tests {
     fn updater_support_matches_the_release_pipeline() {
         assert_eq!(updater_platform_for("windows").ok(), Some("windows"));
         assert!(updater_platform_for("linux").is_err());
+    }
+
+    fn signed_v3_manifest() -> (serde_json::Value, String, String) {
+        let signing_key = SigningKey::from_bytes(&[7_u8; 32]);
+        let artifact_sha256 = "a".repeat(64);
+        let updater_signature = "s".repeat(64);
+        let sigstore_identity =
+            "https://github.com/usesesame/sesame-desktop/.github/workflows/release-early-access.yml@refs/tags/v1.2.3";
+        let payload = [
+            "sesame-release-candidate-v3".to_owned(),
+            "1.2.3".to_owned(),
+            "beta".to_owned(),
+            "windows".to_owned(),
+            "x86_64".to_owned(),
+            "Windows 10,Windows 11".to_owned(),
+            "https://example.invalid/releases/1.2.3".to_owned(),
+            "https://downloads.example.invalid/Sesame.exe".to_owned(),
+            "windows/1.2.3/Sesame.exe".to_owned(),
+            artifact_sha256.clone(),
+            "42".to_owned(),
+            updater_signature.clone(),
+            "fictional-updater-key".to_owned(),
+            "early_access".to_owned(),
+            "true".to_owned(),
+            "https://token.actions.githubusercontent.com".to_owned(),
+            sigstore_identity.to_owned(),
+            "c".repeat(64),
+            "A".repeat(43),
+            "false".to_owned(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ]
+        .join("\n");
+        let signature = URL_SAFE_NO_PAD.encode(signing_key.sign(payload.as_bytes()).to_bytes());
+        let public_key = URL_SAFE_NO_PAD.encode(signing_key.verifying_key().to_bytes());
+        let manifest = json!({
+            "url": "https://downloads.example.invalid/Sesame.exe",
+            "candidateReceipt": {
+                "payload": payload,
+                "signingKeyId": "fictional-candidate-key",
+                "signature": signature,
+            }
+        });
+        (manifest, public_key, updater_signature)
+    }
+
+    #[test]
+    fn verifies_a_v3_receipt_from_clients_before_0_2_3() {
+        let (manifest, public_key, updater_signature) = signed_v3_manifest();
+        let digest = verify_candidate_receipt(
+            &manifest,
+            "1.2.3",
+            &updater_signature,
+            &public_key,
+            "fictional-candidate-key",
+            "windows",
+            "x86_64",
+        )
+        .expect("verify v3 receipt");
+        assert_eq!(digest, "a".repeat(64));
+    }
+
+    #[test]
+    fn rejects_a_v3_receipt_bound_to_another_version_or_download() {
+        let (manifest, public_key, updater_signature) = signed_v3_manifest();
+        assert!(verify_candidate_receipt(
+            &manifest,
+            "9.9.9",
+            &updater_signature,
+            &public_key,
+            "fictional-candidate-key",
+            "windows",
+            "x86_64",
+        )
+        .is_err());
+        let (mut manifest, public_key, updater_signature) = signed_v3_manifest();
+        manifest["url"] = json!("https://downloads.example.invalid/other.exe");
+        assert!(verify_candidate_receipt(
+            &manifest,
+            "1.2.3",
+            &updater_signature,
+            &public_key,
+            "fictional-candidate-key",
+            "windows",
+            "x86_64",
+        )
+        .is_err());
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Sesame",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "app.usesesame.desktop",
   "build": {
     "beforeDevCommand": "npm run desktop:dev",

--- a/tools/create-static-update-manifest.mjs
+++ b/tools/create-static-update-manifest.mjs
@@ -2,7 +2,7 @@ import { createPublicKey, verify } from 'node:crypto'
 import { readFile, writeFile } from 'node:fs/promises'
 import { basename, resolve } from 'node:path'
 
-import { releaseSetSigningPayload, verifyReleaseSet } from './release-set.mjs'
+import { releaseSetSigningPayload, updateReceiptV3, verifyReleaseSet } from './release-set.mjs'
 
 const [candidatePath, outputPath] = process.argv.slice(2)
 if (!candidatePath || !outputPath) {
@@ -75,6 +75,41 @@ if (candidatePublicKey) {
   }
 }
 
+// The manifest receipt must be verifiable by every released client. Clients
+// before 0.2.3 only understand the v3 receipt layout, so the release pipeline
+// provides the separately signed v3 receipt and this manifest ships that.
+const receiptFile = process.env.SESAME_UPDATE_RECEIPT_V3_FILE?.trim()
+let candidateReceipt
+if (receiptFile) {
+  const receipt = JSON.parse(await readFile(resolve(receiptFile), 'utf8'))
+  if (
+    typeof receipt?.payload !== 'string' || receipt.payload !== updateReceiptV3(candidate) ||
+    receipt.signingKeyId !== candidate.candidateSigningKeyId ||
+    typeof receipt.signature !== 'string' || Buffer.from(receipt.signature, 'base64url').length !== 64
+  ) {
+    throw new Error('The provided update receipt does not describe this release set.')
+  }
+  if (candidatePublicKey && !verify(
+    null,
+    Buffer.from(receipt.payload),
+    createPublicKey({
+      key: Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), Buffer.from(candidatePublicKey, 'base64url')]),
+      format: 'der',
+      type: 'spki',
+    }),
+    Buffer.from(receipt.signature, 'base64url'),
+  )) {
+    throw new Error('The update receipt signature does not verify.')
+  }
+  candidateReceipt = { payload: receipt.payload, signingKeyId: receipt.signingKeyId, signature: receipt.signature }
+} else {
+  candidateReceipt = {
+    payload: candidatePayload,
+    signingKeyId: candidate.candidateSigningKeyId,
+    signature: candidate.candidateSignature,
+  }
+}
+
 const target = `${candidate.platform}-${candidate.architecture}-${artifact.format}`
 const manifest = {
   version: candidate.version,
@@ -85,11 +120,7 @@ const manifest = {
       signature: artifact.updaterSignature,
     },
   },
-  candidateReceipt: {
-    payload: candidatePayload,
-    signingKeyId: candidate.candidateSigningKeyId,
-    signature: candidate.candidateSignature,
-  },
+  candidateReceipt,
 }
 
 await writeFile(resolve(outputPath), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')

--- a/tools/create-static-update-manifest.test.mjs
+++ b/tools/create-static-update-manifest.test.mjs
@@ -8,7 +8,7 @@ import { promisify } from 'node:util'
 import test from 'node:test'
 
 import { RELEASE_REPOSITORY, RELEASE_WORKFLOW, SIGSTORE_ISSUER, releaseIdentity } from './release-evidence-lib.mjs'
-import { prepareReleaseSet, releaseSetSigningPayload } from './release-set.mjs'
+import { prepareReleaseSet, releaseSetSigningPayload, updateReceiptV3 } from './release-set.mjs'
 
 const run = promisify(execFile)
 const script = resolve('tools/create-static-update-manifest.mjs')
@@ -56,7 +56,7 @@ function signCandidate(candidate) {
   candidate.candidateSigningKeyId = 'candidate-1'
   candidate.candidateSignature = sign(null, Buffer.from(releaseSetSigningPayload(candidate)), privateKey).toString('base64url')
   const spki = publicKey.export({ format: 'der', type: 'spki' })
-  return { candidate, candidatePublicKey: spki.subarray(spki.length - 32).toString('base64url') }
+  return { candidate, candidatePublicKey: spki.subarray(spki.length - 32).toString('base64url'), privateKey }
 }
 
 function fictionalWindowsCandidate() {
@@ -68,7 +68,7 @@ function fictionalWindowsCandidate() {
     supportedWindows: 'Windows 10,Windows 11',
     releaseNotesUrl: `https://releases.example.test/v${version}`,
     artifacts: [fictionalArtifact('nsis', 'a', {
-      url: `https://releases.example.test/v${version}/Sesame_${version}_x64-setup.exe`,
+      url: `https://github.com/usesesame/sesame-desktop/releases/download/v${version}/Sesame_${version}_x64-setup.exe`,
       objectKey: `windows/v${version}/Sesame_${version}_x64-setup.exe`,
     })],
   }))
@@ -113,6 +113,67 @@ test('static updater manifest carries the updater-capable package and exact set 
     const claims = manifest.candidateReceipt.payload.split('\n')
     assert.equal(claims[11], candidate.artifacts[0].url)
     assert.equal(claims[13], candidate.artifacts[0].sha256)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('static updater manifest ships the v3 receipt released clients verify when it is provided', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'sesame-update-manifest-'))
+  try {
+    const candidatePath = join(directory, 'candidate.json')
+    const receiptPath = join(directory, 'update-receipt.json')
+    const outputPath = join(directory, 'latest.json')
+    const { candidate, candidatePublicKey, privateKey } = fictionalWindowsCandidate()
+    await writeFile(candidatePath, JSON.stringify(candidate))
+    const receipt = {
+      payload: updateReceiptV3(candidate),
+      signingKeyId: candidate.candidateSigningKeyId,
+      signature: sign(null, Buffer.from(updateReceiptV3(candidate)), privateKey).toString('base64url'),
+    }
+    await writeFile(receiptPath, JSON.stringify(receipt))
+    await run(process.execPath, [script, candidatePath, outputPath], {
+      env: {
+        ...process.env,
+        SESAME_PUBLIC_UPDATE_ARTIFACT_URL: `https://github.com/usesesame/sesame-desktop/releases/download/v${version}/Sesame_${version}_x64-setup.exe`,
+        SESAME_RELEASE_CANDIDATE_PUBLIC_KEY: candidatePublicKey,
+        SESAME_UPDATE_RECEIPT_V3_FILE: receiptPath,
+      },
+    })
+    const manifest = JSON.parse(await readFile(outputPath, 'utf8'))
+    assert.equal(manifest.candidateReceipt.signingKeyId, 'candidate-1')
+    assert.equal(manifest.candidateReceipt.payload, receipt.payload)
+    const claims = manifest.candidateReceipt.payload.split('\n')
+    assert.equal(claims[0], 'sesame-release-candidate-v3')
+    assert.equal(claims.length, 23)
+    assert.equal(
+      claims[7],
+      `https://github.com/usesesame/sesame-desktop/releases/download/v${version}/Sesame_${version}_x64-setup.exe`,
+    )
+    assert.equal(claims[11], manifest.platforms['windows-x86_64-nsis'].signature)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('static updater manifest refuses an update receipt that does not describe the release set', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'sesame-update-manifest-'))
+  try {
+    const candidatePath = join(directory, 'candidate.json')
+    const receiptPath = join(directory, 'update-receipt.json')
+    const outputPath = join(directory, 'latest.json')
+    const { candidate } = fictionalWindowsCandidate()
+    await writeFile(candidatePath, JSON.stringify(candidate))
+    const claims = updateReceiptV3(candidate).split('\n')
+    claims[1] = '9.9.9'
+    await writeFile(receiptPath, JSON.stringify({ payload: claims.join('\n'), signingKeyId: 'candidate-1', signature: 'A'.repeat(64) }))
+    await assert.rejects(run(process.execPath, [script, candidatePath, outputPath], {
+      env: {
+        ...process.env,
+        SESAME_PUBLIC_UPDATE_ARTIFACT_URL: `https://github.com/usesesame/sesame-desktop/releases/download/v${version}/Sesame_${version}_x64-setup.exe`,
+        SESAME_UPDATE_RECEIPT_V3_FILE: receiptPath,
+      },
+    }), /does not describe this release set/)
   } finally {
     await rm(directory, { recursive: true, force: true })
   }

--- a/tools/create-updater-artifacts.mjs
+++ b/tools/create-updater-artifacts.mjs
@@ -5,7 +5,7 @@ import { promisify } from 'node:util'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { prepareReleaseSet, releaseSetSigningPayload } from './release-set.mjs'
+import { prepareReleaseSet, releaseSetSigningPayload, updateReceiptV3 } from './release-set.mjs'
 
 const [artifactPath, signaturePath, sigstorePath, authenticodePath] = process.argv.slice(2)
 if (!artifactPath || !signaturePath || !sigstorePath) {
@@ -130,3 +130,16 @@ await mkdir(outputDirectory, { recursive: true })
 const outputPath = path.join(outputDirectory, `sesame-${candidate.version}-${candidate.platform}-${candidate.architecture}.candidate.json`)
 await writeFile(outputPath, `${JSON.stringify(candidate, null, 2)}\n`, 'utf8')
 console.log(`Created verified-candidate input: ${outputPath}`)
+
+// Released clients before 0.2.3 verify the static update manifest against the
+// v3 receipt layout rather than the release-set payload the server ingests.
+// Both receipts bind the same artifact and are signed by the same key.
+const signingKey = createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' })
+const updateReceipt = {
+  payload: updateReceiptV3(candidate),
+  signingKeyId: candidate.candidateSigningKeyId,
+  signature: sign(null, Buffer.from(updateReceiptV3(candidate)), signingKey).toString('base64url'),
+}
+const receiptPath = path.join(outputDirectory, `sesame-${candidate.version}-${candidate.platform}-${candidate.architecture}.update-receipt.json`)
+await writeFile(receiptPath, `${JSON.stringify(updateReceipt, null, 2)}\n`, 'utf8')
+console.log(`Created legacy-format update receipt: ${receiptPath}`)

--- a/tools/release-set.mjs
+++ b/tools/release-set.mjs
@@ -65,6 +65,25 @@ export function releaseSetSigningPayload(releaseSet) {
   ].join('\n')
 }
 
+// Clients released before 0.2.3 verify the static update manifest against this
+// receipt layout, and the 0.2.3 client verifies only the release-set payload.
+// The manifest keeps carrying this format until the installed base is past the
+// client that understands both.
+export function updateReceiptV3(releaseSet) {
+  const artifact = releaseSet.artifacts.find((item) => item.updaterCapable)
+  if (!artifact) throw new Error('An update receipt requires an updater-capable package.')
+  return [
+    'sesame-release-candidate-v3', releaseSet.version, releaseSet.channel, releaseSet.platform,
+    releaseSet.architecture, releaseSet.supportedWindows ?? '', releaseSet.releaseNotesUrl,
+    artifact.url, artifact.objectKey, artifact.sha256, String(artifact.bytes),
+    artifact.updaterSignature ?? '', artifact.updaterSigningKeyId ?? '',
+    artifact.distributionClass, 'true', artifact.sigstoreIssuer, artifact.sigstoreIdentity,
+    artifact.sigstoreBundleSha256, evidenceDigest(artifact.sigstoreEvidence),
+    String(artifact.authenticodeVerified), artifact.authenticodeSubject ?? '',
+    artifact.authenticodeThumbprint ?? '', evidenceDigest(artifact.authenticodeEvidence),
+  ].join('\n')
+}
+
 export function verifyReleaseSet(releaseSet) {
   if (releaseSet?.schemaVersion !== 3 || !versionPattern.test(releaseSet.version) || !channelSet.has(releaseSet.channel)) {
     throw new Error('Release set identity is invalid.')

--- a/tools/verify-updater-vm-lab.mjs
+++ b/tools/verify-updater-vm-lab.mjs
@@ -39,20 +39,20 @@ if (existsSync(updaterVerifier)) {
   })
 }
 const claims = good.candidateReceipt.payload.split('\n')
+// The lab manifest carries the release-set receipt; the verifier also accepts
+// the v3 receipt clients before 0.2.3 require, matching the desktop verifier.
+const setReceipt = claims[0] === 'sesame-release-set-candidate-v1' && claims.length === 17
+const v3Receipt = claims[0] === 'sesame-release-candidate-v3' && claims.length === 23
 if (
-  claims.length !== 17 ||
-  claims[0] !== 'sesame-release-set-candidate-v1' ||
+  (!setReceipt && !v3Receipt) ||
   claims[1] !== good.version ||
   claims[3] !== 'windows' ||
   claims[4] !== 'x86_64' ||
-  claims[7] !== config.releaseSetDigest ||
-  claims[8] !== 'updater' ||
-  claims[9] !== 'nsis' ||
-  claims[10] !== 'x86_64' ||
-  claims[11] !== good.url ||
-  claims[13] !== hash(artifact) ||
-  claims[14] !== String(artifact.length) ||
-  claims[15] !== detachedSignature ||
+  (setReceipt && (claims[7] !== config.releaseSetDigest || claims[8] !== 'updater' || claims[9] !== 'nsis' || claims[10] !== 'x86_64' || claims[11] !== good.url)) ||
+  (v3Receipt && claims[7] !== good.url) ||
+  claims[setReceipt ? 15 : 11] !== detachedSignature ||
+  claims[setReceipt ? 13 : 9] !== hash(artifact) ||
+  claims[setReceipt ? 14 : 10] !== String(artifact.length) ||
   good.signature !== detachedSignature ||
   good.candidateReceipt.signingKeyId !== keys.candidateKeyID
 ) {


### PR DESCRIPTION
## Scope

- Area: build (release pipeline and updater)
- Linked issue: none
- Depends on: none

## What changed

Updating from 0.1.1 through 0.2.2 to 0.2.3 failed: the 0.2.3 release pipeline switched the update-manifest receipt to the release-set format that only the 0.2.3 client verifies, so every earlier client rejected the update as an invalid receipt. The release pipeline now signs and ships the v3 receipt layout every released client verifies in the static manifest (the server still ingests the release-set candidate), and the updater accepts both formats so the two formats can coexist.

## Security and data boundary

- [x] This does not send vault contents, passwords, TOTP seeds, recovery data, or encryption keys to a Sesame service.
- [x] I reviewed changes to unlock, encryption, backup, import, browser messaging, authentication, or audit behaviour.
- [x] Any new logs and diagnostics are secret-safe.
- [ ] Not applicable; this change does not touch a security or data boundary.

The updater receipt verifier now accepts the v3 layout with the exact claim checks the 0.2.2 client enforced (URL binding, version binding, sigstore identity, Authenticode consistency), so accepting the older format does not weaken the verification.

## Validation

```text
npm run desktop:version:check   # passed
npm run desktop:lint:js         # passed
npm run desktop:contracts       # passed, 74 tests (2 new manifest receipt tests)
npm run desktop:lint:rust       # passed, no new clippy findings
cargo test --lib updater        # passed, 7 tests (2 new v3 receipt tests)
npm run desktop:ci              # passed
```

## Evidence

The failing hop: a 0.2.2 client verifies a 23-line sesame-release-candidate-v3 receipt; the 0.2.3 manifest shipped a 17-line sesame-release-set-candidate-v1 receipt. The new manifest carries the v3 receipt and the 0.2.4 client verifies both.

## Review notes

- [x] Generated output and local state are not included.
- [x] Documentation matches the implemented state.
- [x] This change is safe to revert independently, or the dependency is documented above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update verification to support both legacy and v3 receipt formats.
  * Restored compatibility for upgrades from versions 0.1.1–0.2.2 through 0.2.3.
  * Added validation for update metadata, signatures, platform, architecture, and artifact integrity.
  * Update manifests now require a valid receipt before generation.

* **Release**
  * Released version 0.2.4 with updated updater receipt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->