### PR TITLE
Bind the update receipt to a top-level manifest url

### DIFF
--- a/tools/create-static-update-manifest.mjs
+++ b/tools/create-static-update-manifest.mjs
@@ -113,6 +113,7 @@ if (receiptFile) {
 const target = `${candidate.platform}-${candidate.architecture}-${artifact.format}`
 const manifest = {
   version: candidate.version,
+  url: artifactURL.toString(),
   notes: `Verification and release notes: ${candidate.releaseNotesUrl}`,
   platforms: {
     [target]: {

--- a/tools/create-static-update-manifest.test.mjs
+++ b/tools/create-static-update-manifest.test.mjs
@@ -113,6 +113,8 @@ test('static updater manifest carries the updater-capable package and exact set 
     const claims = manifest.candidateReceipt.payload.split('\n')
     assert.equal(claims[11], candidate.artifacts[0].url)
     assert.equal(claims[13], candidate.artifacts[0].sha256)
+    assert.equal(manifest.url, manifest.platforms['windows-x86_64-nsis'].url)
+    assert.equal(manifest.url, claims[11])
   } finally {
     await rm(directory, { recursive: true, force: true })
   }
@@ -151,6 +153,7 @@ test('static updater manifest ships the v3 receipt released clients verify when 
       `https://github.com/usesesame/sesame-desktop/releases/download/v${version}/Sesame_${version}_x64-setup.exe`,
     )
     assert.equal(claims[11], manifest.platforms['windows-x86_64-nsis'].signature)
+    assert.equal(manifest.url, claims[7])
   } finally {
     await rm(directory, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Scope

- Area: build (release pipeline)
- Linked issue: none
- Depends on: none

## What changed

The static update manifest now carries the download URL at the top level as well as under the platform target. The updater hands the whole manifest JSON to the app, and every released client binds the signed receipt to that top-level url. The Tauri static format does not include it, so the receipt binding compared against an empty string and every in-app update failed the receipt check since 0.1.1. The v0.2.4 release asset was regenerated with the fixed tool and replaced on the release.

## Security and data boundary

- [x] This does not send vault contents, passwords, TOTP seeds, recovery data, or encryption keys to a Sesame service.
- [x] I reviewed changes to unlock, encryption, backup, import, browser messaging, authentication, or audit behaviour.
- [x] Any new logs and diagnostics are secret-safe.
- [ ] Not applicable; this change does not touch a security or data boundary.

The receipt payload and signature are unchanged; only an inert top-level field was added, and the binding check compares it against the same URL the receipt already signed.

## Validation

```text
node --test tools/create-static-update-manifest.test.mjs   # passed, 5 tests (2 new url-binding assertions)
npm run desktop:contracts                                   # passed, 74 tests
npm run desktop:lint:js                                     # passed
```

The regenerated 0.2.4 manifest was verified to differ from the shipped one only by the added url field, with the receipt payload and signature byte-identical, before it replaced the release asset.

## Review notes

- [x] Generated output and local state are not included.
- [x] Documentation matches the implemented state.
- [x] This change is safe to revert independently, or the dependency is documented above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static update manifests now include the validated artifact URL at the top level.

* **Tests**
  * Added coverage to verify the manifest URL matches the selected Windows package and signed receipt claims, including scenarios with and without a v3 receipt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->