### PR TITLE
Release sync keys only to verified peers

### DIFF
--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -334,6 +334,7 @@ pub async fn sync_disable(app: AppHandle, force: Option<bool>) -> Result<(), Str
         }
     }
     crate::sync::identity::forget(&path)?;
+    crate::sync::peers::forget(&crate::sync::peers::peers_path(&local_data_dir(&app)?))?;
     crate::sync::state::forget_protected(&crate::sync::state::state_path(&local_data_dir(&app)?))
 }
 

--- a/src-tauri/src/commands/sync_adopt.rs
+++ b/src-tauri/src/commands/sync_adopt.rs
@@ -78,6 +78,13 @@ pub async fn sync_adopt_vault(
         &package.ciphertext,
         &package.signature,
     )?;
+    // The approver's signature just proved this signing key; remember it for later key releases.
+    crate::sync::peers::record_verified(
+        &crate::sync::peers::peers_path(&local_data_dir(&app)?),
+        &current.vault_id,
+        &signer.device_id,
+        &signer.signing_public_key,
+    )?;
 
     let mut vault_key = identity.open_key_package(&sealed, &current.vault_id)?;
     let key: [u8; 32] = vault_key
@@ -90,6 +97,13 @@ pub async fn sync_adopt_vault(
         ed25519_dalek::VerifyingKey::from_bytes(&decode_key(&sender.signing_public_key)?)
             .map_err(|_| "The synced vault could not be verified.".to_string())?;
     crate::sync::envelope::verify(&envelope, &verifying)?;
+    // The uploader's own signature just proved this signing key; remember it for later key releases.
+    crate::sync::peers::record_verified(
+        &crate::sync::peers::peers_path(&local_data_dir(&app)?),
+        &current.vault_id,
+        &sender.device_id,
+        &sender.signing_public_key,
+    )?;
 
     let blob = crate::vault::types::CipherBlob {
         nonce: envelope.nonce.clone(),
@@ -103,6 +117,11 @@ pub async fn sync_adopt_vault(
     )?;
     let payload = authenticated.payload().clone();
     let entry_count = payload.entries.len();
+    let applied_digest = {
+        let plaintext = serde_json::to_vec(&payload)
+            .map_err(|_| "The synced vault could not be prepared.".to_string())?;
+        crate::sync::state::payload_digest(&plaintext)
+    };
 
     let recovery_kit = {
         let mut session = state
@@ -129,8 +148,24 @@ pub async fn sync_adopt_vault(
         recovery_kit
     };
     state.cache_pin_unlock(false);
+    state.cache_hello_unlock(false);
     crate::commands::lifecycle::discard_pin_throttle_state(&app, &state);
     crate::browser_fill::cancel_pending_approvals(&app);
+
+    // The adopted snapshot is this device's compare-and-swap base: without it every upload
+    // conflicts and every download orders a re-join.
+    crate::sync::state::write_protected(
+        &crate::sync::state::state_path(&local_data_dir(&app)?),
+        &crate::sync::state::SyncBase {
+            version: 1,
+            vault_id: current.vault_id.clone(),
+            revision: current.revision,
+            vault_epoch: current.vault_epoch,
+            payload_digest: applied_digest,
+            head_digest: crate::sync::envelope::digest(&envelope),
+            receipt: current.receipt.clone(),
+        },
+    )?;
 
     Ok(SyncAdoptResult {
         entry_count,
@@ -139,7 +174,7 @@ pub async fn sync_adopt_vault(
     })
 }
 
-/// Old-key wraps are rebuilt or dropped; a stale PIN wrap would unlock a vault this one cannot read.
+/// Old-key wraps are rebuilt or dropped; a stale PIN or Hello wrap would unlock a vault this one cannot read.
 pub(super) fn adopt(
     vault: &mut crate::vault::UnlockedVault,
     mut key: [u8; 32],
@@ -159,12 +194,16 @@ pub(super) fn adopt(
 
     let protected_key = crate::vault::VaultKey::new(key)?;
     key.zeroize();
+    // A stale Hello wrap would wrap the old key; cleared with everything else and only
+    // persisted as part of this same replacement.
+    let stale_hello = vault.hello_wrap.take();
     let previous = (
         std::mem::replace(&mut vault.kdf, kdf),
         std::mem::replace(&mut vault.key_wrap, key_wrap),
         std::mem::replace(&mut vault.recovery_kdf, Some(recovery_kdf)),
         std::mem::replace(&mut vault.recovery_wrap, Some(recovery_wrap)),
         std::mem::replace(&mut vault.pin_wrap, None),
+        stale_hello,
         vault.replace_vault_key(protected_key),
     );
 
@@ -177,8 +216,13 @@ pub(super) fn adopt(
         vault.recovery_kdf = previous.2;
         vault.recovery_wrap = previous.3;
         vault.pin_wrap = previous.4;
-        vault.replace_vault_key(previous.5);
+        vault.hello_wrap = previous.5;
+        vault.replace_vault_key(previous.6);
         return Err(error);
+    }
+    // The obsolete platform key goes only after the file no longer references it.
+    if let Some(old) = previous.5 {
+        crate::vault::windows_hello::delete_key(&old.key_name);
     }
     Ok(shown)
 }

--- a/src-tauri/src/commands/sync_adopt.rs
+++ b/src-tauri/src/commands/sync_adopt.rs
@@ -78,7 +78,6 @@ pub async fn sync_adopt_vault(
         &package.ciphertext,
         &package.signature,
     )?;
-    // The approver's signature just proved this signing key; remember it for later key releases.
     crate::sync::peers::record_verified(
         &crate::sync::peers::peers_path(&local_data_dir(&app)?),
         &current.vault_id,
@@ -97,7 +96,6 @@ pub async fn sync_adopt_vault(
         ed25519_dalek::VerifyingKey::from_bytes(&decode_key(&sender.signing_public_key)?)
             .map_err(|_| "The synced vault could not be verified.".to_string())?;
     crate::sync::envelope::verify(&envelope, &verifying)?;
-    // The uploader's own signature just proved this signing key; remember it for later key releases.
     crate::sync::peers::record_verified(
         &crate::sync::peers::peers_path(&local_data_dir(&app)?),
         &current.vault_id,
@@ -152,8 +150,6 @@ pub async fn sync_adopt_vault(
     crate::commands::lifecycle::discard_pin_throttle_state(&app, &state);
     crate::browser_fill::cancel_pending_approvals(&app);
 
-    // The adopted snapshot is this device's compare-and-swap base: without it every upload
-    // conflicts and every download orders a re-join.
     crate::sync::state::write_protected(
         &crate::sync::state::state_path(&local_data_dir(&app)?),
         &crate::sync::state::SyncBase {
@@ -174,7 +170,7 @@ pub async fn sync_adopt_vault(
     })
 }
 
-/// Old-key wraps are rebuilt or dropped; a stale PIN or Hello wrap would unlock a vault this one cannot read.
+/// Old-key wraps are rebuilt or dropped; a stale PIN wrap would unlock a vault this one cannot read.
 pub(super) fn adopt(
     vault: &mut crate::vault::UnlockedVault,
     mut key: [u8; 32],
@@ -194,8 +190,6 @@ pub(super) fn adopt(
 
     let protected_key = crate::vault::VaultKey::new(key)?;
     key.zeroize();
-    // A stale Hello wrap would wrap the old key; cleared with everything else and only
-    // persisted as part of this same replacement.
     let stale_hello = vault.hello_wrap.take();
     let previous = (
         std::mem::replace(&mut vault.kdf, kdf),
@@ -220,7 +214,6 @@ pub(super) fn adopt(
         vault.replace_vault_key(previous.6);
         return Err(error);
     }
-    // The obsolete platform key goes only after the file no longer references it.
     if let Some(old) = previous.5 {
         crate::vault::windows_hello::delete_key(&old.key_name);
     }

--- a/src-tauri/src/commands/sync_transfer.rs
+++ b/src-tauri/src/commands/sync_transfer.rs
@@ -74,7 +74,6 @@ pub(super) async fn approve_frozen_device(
         )
         .await
         .map_err(present)?;
-    // The person just compared these keys aloud; pin them so later releases detect substitution.
     crate::sync::peers::record_approved(
         &crate::sync::peers::peers_path(&local_data_dir(&app)?),
         &current.vault_id,
@@ -328,7 +327,6 @@ async fn fetch_verified_snapshot(
         ed25519_dalek::VerifyingKey::from_bytes(&decode_key(&sender.signing_public_key)?)
             .map_err(|_| "The synced vault could not be verified.".to_string())?;
     crate::sync::envelope::verify(&envelope, &verifying)?;
-    // The sender's own signature just proved this signing key; remember it for later key releases.
     crate::sync::peers::record_verified(
         &crate::sync::peers::peers_path(&local_data_dir(app)?),
         &current.vault_id,
@@ -407,8 +405,6 @@ pub async fn sync_remove_device(
     let device_epoch = this_device_epoch(&client, &identity.device_id).await?;
     let new_epoch = current.vault_epoch.max(1) as u64 + 1;
 
-    // Key release compares against remembered trust, never the listing alone: a compromised
-    // service can relist any device with its own encryption key and otherwise read the package.
     let peers = crate::sync::peers::peers_path(&local_data_dir(&app)?);
     for survivor in &survivors {
         crate::sync::peers::require_releasable(

--- a/src-tauri/src/commands/sync_transfer.rs
+++ b/src-tauri/src/commands/sync_transfer.rs
@@ -74,6 +74,14 @@ pub(super) async fn approve_frozen_device(
         )
         .await
         .map_err(present)?;
+    // The person just compared these keys aloud; pin them so later releases detect substitution.
+    crate::sync::peers::record_approved(
+        &crate::sync::peers::peers_path(&local_data_dir(&app)?),
+        &current.vault_id,
+        &device_id,
+        frozen_signing_key,
+        frozen_encryption_key,
+    )?;
     Ok(SyncDeviceView {
         is_this_device: false,
         // The frozen keys, not this response's: the person never confirmed those.
@@ -205,7 +213,7 @@ pub async fn sync_download_vault(
     state: tauri::State<'_, VaultState>,
 ) -> Result<SyncTransferResult, String> {
     let client = SyncClient::connect(&app)?;
-    let (current, envelope, _) = fetch_verified_snapshot(&client).await?;
+    let (current, envelope, _) = fetch_verified_snapshot(&app, &client).await?;
 
     let state_file = crate::sync::state::state_path(&local_data_dir(&app)?);
     let base = match crate::sync::state::read_protected(&state_file) {
@@ -289,6 +297,7 @@ pub async fn sync_download_vault(
 
 /// Downloads and verifies the snapshot: sender approval, signature, and response agreement.
 async fn fetch_verified_snapshot(
+    app: &AppHandle,
     client: &SyncClient,
 ) -> Result<
     (
@@ -319,6 +328,13 @@ async fn fetch_verified_snapshot(
         ed25519_dalek::VerifyingKey::from_bytes(&decode_key(&sender.signing_public_key)?)
             .map_err(|_| "The synced vault could not be verified.".to_string())?;
     crate::sync::envelope::verify(&envelope, &verifying)?;
+    // The sender's own signature just proved this signing key; remember it for later key releases.
+    crate::sync::peers::record_verified(
+        &crate::sync::peers::peers_path(&local_data_dir(app)?),
+        &current.vault_id,
+        &sender.device_id,
+        &sender.signing_public_key,
+    )?;
 
     if envelope.vault_id != current.vault_id
         || envelope.revision as i64 != current.revision
@@ -390,6 +406,19 @@ pub async fn sync_remove_device(
 
     let device_epoch = this_device_epoch(&client, &identity.device_id).await?;
     let new_epoch = current.vault_epoch.max(1) as u64 + 1;
+
+    // Key release compares against remembered trust, never the listing alone: a compromised
+    // service can relist any device with its own encryption key and otherwise read the package.
+    let peers = crate::sync::peers::peers_path(&local_data_dir(&app)?);
+    for survivor in &survivors {
+        crate::sync::peers::require_releasable(
+            &peers,
+            &current.vault_id,
+            &survivor.device_id,
+            &survivor.signing_public_key,
+            &survivor.encryption_public_key,
+        )?;
+    }
 
     // Old key never sent anywhere; it is dropped with the session.
     let mut new_key = [0_u8; 32];
@@ -586,7 +615,7 @@ pub async fn sync_conflict_details(
     state: tauri::State<'_, VaultState>,
 ) -> Result<SyncConflictView, String> {
     let client = SyncClient::connect(&app)?;
-    let (current, envelope, sender_label) = fetch_verified_snapshot(&client).await?;
+    let (current, envelope, sender_label) = fetch_verified_snapshot(&app, &client).await?;
     let state_file = crate::sync::state::state_path(&local_data_dir(&app)?);
     let base = crate::sync::state::read_protected(&state_file);
 
@@ -640,7 +669,7 @@ pub async fn sync_resolve_conflict(
 
     let client = SyncClient::connect(&app)?;
     let identity = this_identity(&app)?;
-    let (current, envelope, _) = fetch_verified_snapshot(&client).await?;
+    let (current, envelope, _) = fetch_verified_snapshot(&app, &client).await?;
     let device_epoch = this_device_epoch(&client, &identity.device_id).await?;
     let data_dir = local_data_dir(&app)?;
     let state_file = crate::sync::state::state_path(&data_dir);

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -14,3 +14,5 @@ pub(crate) use crate::adapters::network::sync as client;
 pub mod conflict_backup;
 #[cfg(feature = "sync-preview")]
 pub mod coordinator;
+#[cfg(feature = "sync-preview")]
+pub mod peers;

--- a/src-tauri/src/sync/peers.rs
+++ b/src-tauri/src/sync/peers.rs
@@ -1,0 +1,273 @@
+//! Remembered Sync peer keys this profile has already trusted. The service directory is not a
+//! trust anchor: a compromised service can relist any device with its own keys, so key release
+//! compares against what this device verified itself, never against the listing alone.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::vault::VaultResult;
+
+pub const PEERS_FILE_NAME: &str = "sync-peers.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustedPeer {
+    pub signing_public_key: String,
+    /// Empty unless a person compared this device's approval fingerprint on this profile.
+    pub encryption_public_key: String,
+    pub approved_here: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredPeers {
+    version: u8,
+    vault_id: String,
+    devices: BTreeMap<String, TrustedPeer>,
+}
+
+pub fn peers_path(app_local_data_dir: &Path) -> PathBuf {
+    app_local_data_dir.join(PEERS_FILE_NAME)
+}
+
+fn tag_path(path: &Path) -> PathBuf {
+    path.with_extension("json.tag")
+}
+
+fn peers_tag(body: &[u8]) -> Vec<u8> {
+    let mut digest = Sha256::new();
+    digest.update(b"sesame-sync-peers-tag-v1");
+    digest.update((body.len() as u64).to_be_bytes());
+    digest.update(body);
+    digest.finalize().to_vec()
+}
+
+/// Unreadable or foreign files read as no remembered trust; every later decision fails closed.
+fn read_store(path: &Path) -> Option<StoredPeers> {
+    let body = std::fs::read(path).ok()?;
+    let protected = std::fs::read(tag_path(path)).ok()?;
+    let expected = crate::vault::platform::unprotect_for_device(&protected).ok()?;
+    let actual = peers_tag(&body);
+    if actual.len() != expected.len()
+        || actual
+            .iter()
+            .zip(expected.iter())
+            .fold(0_u8, |differences, (left, right)| {
+                differences | (left ^ right)
+            })
+            != 0
+    {
+        return None;
+    }
+    let store: StoredPeers = serde_json::from_slice(&body).ok()?;
+    if store.version != 1 {
+        return None;
+    }
+    Some(store)
+}
+
+fn write_store(path: &Path, store: &StoredPeers) -> VaultResult<()> {
+    let body = serde_json::to_vec(store)
+        .map_err(|_| "Sesame could not record the trusted Sync devices.".to_string())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|_| "Sesame could not record the trusted Sync devices.".to_string())?;
+    }
+    let protected = crate::vault::platform::protect_for_device(&peers_tag(&body))
+        .map_err(|_| "Sesame could not record the trusted Sync devices.".to_string())?;
+    crate::vault::storage::atomic_replace(&tag_path(path), &protected)?;
+    crate::vault::storage::atomic_replace(path, &body)
+}
+
+fn load_or_init(path: &Path, vault_id: &str) -> StoredPeers {
+    match read_store(path) {
+        Some(store) if store.vault_id == vault_id => store,
+        // A deliberate vault switch starts trust over; pins never carry between vaults.
+        _ => StoredPeers {
+            version: 1,
+            vault_id: vault_id.to_string(),
+            devices: BTreeMap::new(),
+        },
+    }
+}
+
+/// Remembers a signing key this device just authenticated with the peer's own signature.
+pub fn record_verified(
+    path: &Path,
+    vault_id: &str,
+    device_id: &str,
+    signing_public_key: &str,
+) -> VaultResult<()> {
+    let mut store = load_or_init(path, vault_id);
+    if let Some(existing) = store.devices.get(device_id) {
+        if existing.signing_public_key != signing_public_key {
+            return Err(
+                "The service reported different signing keys for a Sync device this one already verified. Sync is paused for safety; remove and re-add the device."
+                    .into(),
+            );
+        }
+        return Ok(());
+    }
+    store.devices.insert(
+        device_id.to_string(),
+        TrustedPeer {
+            signing_public_key: signing_public_key.to_string(),
+            encryption_public_key: String::new(),
+            approved_here: false,
+        },
+    );
+    write_store(path, &store)
+}
+
+/// Remembers both keys of a device whose fingerprint a person compared on this profile.
+pub fn record_approved(
+    path: &Path,
+    vault_id: &str,
+    device_id: &str,
+    signing_public_key: &str,
+    encryption_public_key: &str,
+) -> VaultResult<()> {
+    let mut store = load_or_init(path, vault_id);
+    if let Some(existing) = store.devices.get(device_id) {
+        if existing.signing_public_key != signing_public_key
+            || (existing.approved_here && existing.encryption_public_key != encryption_public_key)
+        {
+            return Err(
+                "The service reported different keys for a Sync device this one already verified. Sync is paused for safety; remove and re-add the device."
+                    .into(),
+            );
+        }
+    }
+    store.devices.insert(
+        device_id.to_string(),
+        TrustedPeer {
+            signing_public_key: signing_public_key.to_string(),
+            encryption_public_key: encryption_public_key.to_string(),
+            approved_here: true,
+        },
+    );
+    write_store(path, &store)
+}
+
+/// Guards one key release: the listing must agree with what this device remembers trusting.
+pub fn require_releasable(
+    path: &Path,
+    vault_id: &str,
+    device_id: &str,
+    listing_signing_key: &str,
+    listing_encryption_key: &str,
+) -> Result<(), String> {
+    let substituted = || {
+        "The service reported different keys for a Sync device this one already verified. Sync is paused for safety; remove and re-add the device."
+    };
+    let store = read_store(path).ok_or_else(|| {
+        "This device has not verified that device's Sync keys. Remove it from the device that approved it, which also protects the vault key, or turn Sync off on it."
+    })?;
+    if store.vault_id != vault_id {
+        return Err(
+            "This device has not verified that device's Sync keys. Remove it from the device that approved it, which also protects the vault key, or turn Sync off on it."
+                .into(),
+        );
+    }
+    let pin = store.devices.get(device_id).ok_or_else(|| {
+        "This device has not verified that device's Sync keys. Remove it from the device that approved it, which also protects the vault key, or turn Sync off on it."
+    })?;
+    if pin.signing_public_key != listing_signing_key {
+        return Err(substituted().into());
+    }
+    if !pin.approved_here || pin.encryption_public_key.is_empty() {
+        return Err(
+            "This device has not verified that device's key in an approval. Remove it from the device that approved it, which also protects the vault key, or turn Sync off on it."
+                .into(),
+        );
+    }
+    if pin.encryption_public_key != listing_encryption_key {
+        return Err(substituted().into());
+    }
+    Ok(())
+}
+
+pub fn forget(path: &Path) -> VaultResult<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(_) => Err("Sesame could not remove the trusted Sync devices.".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path_for(dir: &Path) -> PathBuf {
+        dir.join(PEERS_FILE_NAME)
+    }
+
+    fn cleanup(dir: &Path) {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    const VAULT: &str = "vault-1";
+    const SIGNING: &str = "signing-key-b64";
+    const SIGNING_OTHER: &str = "signing-key-other";
+    const ENCRYPTION: &str = "encryption-key-b64";
+    const ENCRYPTION_OTHER: &str = "encryption-key-other";
+
+    #[test]
+    fn verified_pins_accumulate_and_refuse_substitution() {
+        let dir =
+            std::env::temp_dir().join(format!("sesame-peers-verified-{}", std::process::id()));
+        let path = path_for(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        record_verified(&path, VAULT, "device-a", SIGNING).unwrap();
+        record_verified(&path, VAULT, "device-a", SIGNING).unwrap();
+        assert!(record_verified(&path, VAULT, "device-a", SIGNING_OTHER).is_err());
+        require_releasable(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap_err();
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn approved_pins_release_and_detect_key_swaps() {
+        let dir =
+            std::env::temp_dir().join(format!("sesame-peers-approved-{}", std::process::id()));
+        let path = path_for(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        require_releasable(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap_err();
+        record_verified(&path, VAULT, "device-a", SIGNING).unwrap();
+        require_releasable(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap_err();
+        record_approved(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap();
+        require_releasable(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap();
+        require_releasable(&path, VAULT, "device-a", SIGNING_OTHER, ENCRYPTION).unwrap_err();
+        require_releasable(&path, VAULT, "device-a", SIGNING, ENCRYPTION_OTHER).unwrap_err();
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn pins_do_not_carry_between_vaults_or_survive_a_foreign_file() {
+        let dir = std::env::temp_dir().join(format!("sesame-peers-vaults-{}", std::process::id()));
+        let path = path_for(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        record_approved(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap();
+        require_releasable(&path, "other-vault", "device-a", SIGNING, ENCRYPTION).unwrap_err();
+        std::fs::write(&path, b"{tampered}").unwrap();
+        require_releasable(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap_err();
+        record_approved(&path, VAULT, "device-b", SIGNING, ENCRYPTION).unwrap();
+        require_releasable(&path, VAULT, "device-b", SIGNING, ENCRYPTION).unwrap();
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn approval_rejects_conflicting_prior_pins() {
+        let dir =
+            std::env::temp_dir().join(format!("sesame-peers-conflict-{}", std::process::id()));
+        let path = path_for(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        record_approved(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap();
+        assert!(record_approved(&path, VAULT, "device-a", SIGNING_OTHER, ENCRYPTION).is_err());
+        assert!(record_approved(&path, VAULT, "device-a", SIGNING, ENCRYPTION_OTHER).is_err());
+        record_approved(&path, VAULT, "device-a", SIGNING, ENCRYPTION).unwrap();
+        cleanup(&dir);
+    }
+}

--- a/src-tauri/src/sync/peers.rs
+++ b/src-tauri/src/sync/peers.rs
@@ -1,7 +1,3 @@
-//! Remembered Sync peer keys this profile has already trusted. The service directory is not a
-//! trust anchor: a compromised service can relist any device with its own keys, so key release
-//! compares against what this device verified itself, never against the listing alone.
-
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -16,7 +12,6 @@ pub const PEERS_FILE_NAME: &str = "sync-peers.json";
 #[serde(rename_all = "camelCase")]
 pub struct TrustedPeer {
     pub signing_public_key: String,
-    /// Empty unless a person compared this device's approval fingerprint on this profile.
     pub encryption_public_key: String,
     pub approved_here: bool,
 }
@@ -44,7 +39,6 @@ fn peers_tag(body: &[u8]) -> Vec<u8> {
     digest.finalize().to_vec()
 }
 
-/// Unreadable or foreign files read as no remembered trust; every later decision fails closed.
 fn read_store(path: &Path) -> Option<StoredPeers> {
     let body = std::fs::read(path).ok()?;
     let protected = std::fs::read(tag_path(path)).ok()?;
@@ -84,7 +78,6 @@ fn write_store(path: &Path, store: &StoredPeers) -> VaultResult<()> {
 fn load_or_init(path: &Path, vault_id: &str) -> StoredPeers {
     match read_store(path) {
         Some(store) if store.vault_id == vault_id => store,
-        // A deliberate vault switch starts trust over; pins never carry between vaults.
         _ => StoredPeers {
             version: 1,
             vault_id: vault_id.to_string(),
@@ -93,7 +86,6 @@ fn load_or_init(path: &Path, vault_id: &str) -> StoredPeers {
     }
 }
 
-/// Remembers a signing key this device just authenticated with the peer's own signature.
 pub fn record_verified(
     path: &Path,
     vault_id: &str,
@@ -121,7 +113,6 @@ pub fn record_verified(
     write_store(path, &store)
 }
 
-/// Remembers both keys of a device whose fingerprint a person compared on this profile.
 pub fn record_approved(
     path: &Path,
     vault_id: &str,
@@ -151,7 +142,6 @@ pub fn record_approved(
     write_store(path, &store)
 }
 
-/// Guards one key release: the listing must agree with what this device remembers trusting.
 pub fn require_releasable(
     path: &Path,
     vault_id: &str,


### PR DESCRIPTION
## Scope

- Area: native host
- Linked issue:
- Depends on: #51 (stacked on its branch; GitHub retargets this pull request to main when that branch is deleted after merge)

## What changed

Three defects from the owner review of the Sync preview, all fail-closed:

Rotation trusted the service's device listing for recipient keys: a compromised service could relist a survivor with its own encryption key and otherwise read the rotation package. Rotation now checks every survivor against a device-protected remembered-trust store (sync/peers.rs). Pins are written when this profile approves a device after the fingerprint comparison and whenever a peer's own signature verifies an envelope or key package. A listing key that contradicts a pin, or a survivor this profile never authenticated, refuses the release before any key material is generated. The operational consequence: removals originate from the approving device, which holds the pins.

Adoption installed the adopted vault without recording the Sync checkpoint: subsequent uploads always conflicted and downloads ordered a re-join. Adoption now writes the protected SyncBase (revision, epoch, payload digest, head digest, receipt) after the install succeeds.

Adoption kept the Windows Hello wrap of the old key: after locking, Hello could not unlock the replacement vault. The wrap is now cleared inside the same replacement transaction, restored on a failed write, and the obsolete platform key is deleted only after the write succeeds. sync_disable also removes the remembered-peer store.

## Security and data boundary

- [x] This does not send vault contents, passwords, TOTP seeds, recovery data, or encryption keys to a Sesame service.
- [x] I reviewed changes to unlock, encryption, backup, import, browser messaging, authentication, or audit behaviour.
- [x] Any new logs and diagnostics are secret-safe.
- [ ] Not applicable; this change does not touch a security or data boundary.

The peer store is DPAPI/device-protected with the same tag scheme as the Sync state file, holds public keys only, and never leaves the device. Key release now fails closed against a lying directory.

## Validation

```text
npm run desktop:lint:rust: passed (only the pre-existing vendored glib warnings)
cargo test --manifest-path src-tauri/Cargo.toml --features sync-preview -- peers: 4 tests passed
npm run desktop:ci: passed in full, including 87 desktop and 109 core tests, every Sync preview suite, contracts, frontend checks and build, and the optimized GLib regression test
git diff --check: passed
```

## Evidence

The peer store carries one deliberate preview restriction: a device can only rotate out devices it authenticated itself (approved here, or signature-verified through synced data). A third-party-approved survivor is refused with an actionable message; the approving device, which holds the pins, removes it.

## Review notes

- [x] Generated output and local state are not included.
- [x] Documentation matches the implemented state.
- [x] This change is safe to revert independently, or the dependency is documented above.
