### PR TITLE
Reject vault saves above the reader's size limit

### DIFF
--- a/src-tauri/sesame-core/src/storage.rs
+++ b/src-tauri/sesame-core/src/storage.rs
@@ -18,7 +18,8 @@ use crate::{
     payload_aad_for_file,
     record_store::VaultRecordStore,
     throttle::{PersistedPinThrottle, PinAttemptGuard},
-    UnlockedVault, VaultResult, PIN_WRAP_AAD, RECOVERY_WRAP_AAD, VAULT_FORMAT_VERSION, WRAP_AAD,
+    UnlockedVault, VaultResult, MAX_VAULT_FILE_BYTES, PIN_WRAP_AAD, RECOVERY_WRAP_AAD,
+    VAULT_FORMAT_VERSION, WRAP_AAD,
 };
 use crate::{
     types::*,
@@ -79,22 +80,19 @@ pub fn write_vault_file(path: &Path, file: &VaultFile) -> VaultResult<()> {
 
 /// No `.prev` copy: one would sit decryptable under the old password.
 pub fn write_vault_file_without_previous(path: &Path, file: &VaultFile) -> VaultResult<()> {
-    let previous = path.with_extension("sesame.prev");
-    match fs::remove_file(previous) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(_) => return Err("Sesame could not remove the previous vault wrapper.".into()),
-    }
     write_vault_file_inner(path, file, false)
 }
 
 fn write_vault_file_inner(path: &Path, file: &VaultFile, retain_previous: bool) -> VaultResult<()> {
+    let bytes = serde_json::to_vec(file)
+        .map_err(|_| "Sesame could not save the local vault.".to_string())?;
+    if bytes.len() as u64 > MAX_VAULT_FILE_BYTES {
+        return Err("This change would exceed the vault's 64 MiB storage limit. Remove unneeded attachments or records and try again. Your saved vault has not changed.".into());
+    }
     let parent = path
         .parent()
         .ok_or("Sesame could not find the local vault folder.")?;
     create_private_dir(parent)?;
-    let bytes = serde_json::to_vec(file)
-        .map_err(|_| "Sesame could not save the local vault.".to_string())?;
     let tmp_path = path.with_extension("sesame.tmp");
     let mut tmp = open_private_file(&tmp_path)?;
     tmp.write_all(&bytes)
@@ -106,6 +104,12 @@ fn write_vault_file_inner(path: &Path, file: &VaultFile, retain_previous: bool) 
         let previous = path.with_extension("sesame.prev");
         copy_private_file(path, &previous)
             .map_err(|_| "Sesame could not protect the previous vault copy.".to_string())?;
+    } else if !retain_previous {
+        match fs::remove_file(path.with_extension("sesame.prev")) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Err("Sesame could not remove the previous vault wrapper.".into()),
+        }
     }
     replace_file(&tmp_path, path)
 }

--- a/src-tauri/sesame-core/tests/vault_save_limits.rs
+++ b/src-tauri/sesame-core/tests/vault_save_limits.rs
@@ -1,0 +1,131 @@
+use std::{fs, path::PathBuf};
+
+use sesame_core::{
+    api,
+    loader::{Credential, VaultLoader},
+    random_id,
+    storage::{
+        commit_payload_change, persist_session, write_vault_file, write_vault_file_without_previous,
+    },
+    Attachment, DocumentMetadata, UnlockedVault, MAX_VAULT_FILE_BYTES,
+};
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new() -> Self {
+        Self(std::env::temp_dir().join(format!("sesame-save-limit-{}", random_id())))
+    }
+
+    fn path(&self) -> PathBuf {
+        self.0.join("vault.sesame")
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn vault_writer_accepts_the_reader_limit_and_rejects_the_next_byte_without_writes() {
+    let directory = TestDirectory::new();
+    let path = directory.path();
+    let (opened, _) = api::create_vault("fictional review password", "Fictional vault")
+        .expect("create fictional vault");
+    let mut file = opened.file.clone();
+    file.legacy_device_wrap = Some(String::new());
+    let overhead = serde_json::to_vec(&file).expect("encode fixture").len();
+    file.legacy_device_wrap = Some("a".repeat(MAX_VAULT_FILE_BYTES as usize - overhead));
+    write_vault_file(&path, &file).expect("save at the reader limit");
+    let saved = fs::read(&path).expect("saved bytes");
+    assert_eq!(saved.len() as u64, MAX_VAULT_FILE_BYTES);
+    VaultLoader::load(
+        &saved,
+        Credential::MasterPassword("fictional review password"),
+    )
+    .expect("authenticate saved vault");
+    let previous = path.with_extension("sesame.prev");
+    write_vault_file(&path, &file).expect("create previous copy");
+    assert_eq!(fs::read(&previous).expect("previous bytes"), saved);
+    file.legacy_device_wrap.as_mut().expect("padding").push('a');
+    for writer in [write_vault_file, write_vault_file_without_previous] {
+        assert!(writer(&path, &file).is_err());
+        assert_eq!(fs::read(&path).expect("active preserved"), saved);
+        assert_eq!(fs::read(&previous).expect("previous preserved"), saved);
+        assert!(!path.with_extension("sesame.tmp").exists());
+    }
+}
+
+#[test]
+fn oversized_initial_save_creates_no_directory_or_file() {
+    let directory = TestDirectory::new();
+    let (opened, _) = api::create_vault("fictional review password", "Fictional vault")
+        .expect("create fictional vault");
+    let mut file = opened.file.clone();
+    file.payload.ciphertext = "a".repeat(MAX_VAULT_FILE_BYTES as usize);
+    for writer in [write_vault_file, write_vault_file_without_previous] {
+        assert!(writer(&directory.path(), &file).is_err());
+        assert!(!directory.0.exists());
+    }
+}
+
+#[test]
+fn oversized_attachment_changes_preserve_both_files_and_session_then_allow_a_smaller_save() {
+    let directory = TestDirectory::new();
+    let path = directory.path();
+    let (opened, _) = api::create_vault("fictional review password", "Fictional vault")
+        .expect("create fictional vault");
+    let mut session = UnlockedVault::from_opened(path.clone(), &opened).expect("session");
+    session.setup_complete = true;
+    persist_session(&mut session).expect("initial save");
+    persist_session(&mut session).expect("create previous copy");
+    let active = fs::read(&path).expect("active bytes");
+    let previous = fs::read(path.with_extension("sesame.prev")).expect("previous bytes");
+    let original = session.open_payload().expect("original payload");
+    let revision = original.revision;
+    let mut changed = original.clone();
+    drop(original);
+    for document_index in 0..2 {
+        let mut document = DocumentMetadata {
+            id: format!("fictional-document-{document_index}"),
+            title: "Fictional document".into(),
+            revision: 1,
+            ..DocumentMetadata::default()
+        };
+        for index in 0..4 {
+            let size = 5 * 1024 * 1024;
+            document.attachments.push(Attachment {
+                id: format!("fictional-attachment-{document_index}-{index}"),
+                filename: "fictional.bin".into(),
+                content_type: "application/octet-stream".into(),
+                size: size as u64,
+                data: vec![42; size],
+            });
+        }
+        changed.documents.push(document);
+    }
+    assert!(commit_payload_change(&mut session, changed).is_err());
+    assert_eq!(fs::read(&path).expect("active preserved"), active);
+    assert_eq!(
+        fs::read(path.with_extension("sesame.prev")).expect("previous preserved"),
+        previous
+    );
+    assert!(!path.with_extension("sesame.tmp").exists());
+    let current = session.open_payload().expect("unchanged session");
+    assert_eq!(current.revision, revision);
+    assert!(current.documents.is_empty());
+    let mut smaller = current.clone();
+    drop(current);
+    smaller.vault_name = "Fictional renamed vault".into();
+    commit_payload_change(&mut session, smaller).expect("smaller save");
+    let file = VaultLoader::read(&path).expect("read saved vault");
+    let reopened = VaultLoader::open(
+        &file,
+        Credential::MasterPassword("fictional review password"),
+    )
+    .expect("authenticate saved vault");
+    assert_eq!(reopened.payload.vault_name, "Fictional renamed vault");
+    assert_eq!(reopened.payload.revision, revision + 1);
+}


### PR DESCRIPTION
## Scope

- Area: vault core
- Linked issue: none
- Depends on: nothing

## What changed

The shared vault writer measures the final encoded file before it writes anything. A save above the loader's 64 MiB limit is rejected before the vault folder is created, a temporary file is written, the active file is replaced, or the previous copy changes. The password-change writer goes through the same check. Rejection leaves the session state unchanged, so a smaller save can succeed right after.

## Security and data boundary

- [x] This does not send vault contents, passwords, TOTP seeds, recovery data, or encryption keys to a Sesame service.
- [x] I reviewed changes to unlock, encryption, backup, import, browser messaging, authentication, or audit behaviour.
- [x] Any new logs and diagnostics are secret-safe.

The change keeps persistence inside the size the loader accepts, so a successful save can no longer produce a file the app cannot reopen. The active file, the previous copy, and the session survive every rejection. The new tests use fictional vaults and no new diagnostics were added.

## Validation

```text
npm run desktop:lint:rust        passed
npm run desktop:test:rust        passed (23 suites, including the new vault_save_limits tests)
```

The tests cover a file exactly at the reader limit, the first rejected byte, oversized initial saves that create no directory or file, oversized attachment changes that preserve both files and the session, and a smaller save that succeeds afterward.

## Evidence

Local runs on this branch. No CI run yet.

## Review notes

- [x] Generated output and local state are not included.
- [x] Documentation matches the implemented state.
- [x] This change is safe to revert independently, or the dependency is documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault saves now reject files larger than 64 MiB with a clear error.
  * Failed oversized saves no longer alter existing vault data, session state, or leave temporary files.
  * Initial oversized saves no longer create empty directories or files.
  * Previous vault backups are handled consistently during saves.

* **Tests**
  * Added coverage for size-limit enforcement, boundary-sized saves, failed updates, and recovery with smaller updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->