### PR TITLE
Make vault files safer to open and save

### DIFF
--- a/src-tauri/sesame-core/src/crypto.rs
+++ b/src-tauri/sesame-core/src/crypto.rs
@@ -9,7 +9,7 @@ use zeroize::Zeroizing;
 
 use crate::{
     types::*, util::fill_random, VaultResult, MAX_KDF_ITERATIONS, MAX_KDF_MEMORY_KIB,
-    MAX_KDF_PARALLELISM,
+    MAX_KDF_PARALLELISM, MAX_KDF_TOTAL_WORK,
 };
 
 pub fn default_kdf_params() -> KdfParams {
@@ -53,6 +53,9 @@ pub fn validate_kdf_params(params: &KdfParams) -> VaultResult<()> {
         || params.parallelism == 0
         || params.parallelism > MAX_KDF_PARALLELISM
     {
+        return Err("The vault KDF settings are outside Sesame's safe limits.".into());
+    }
+    if u64::from(params.memory_kib) * u64::from(params.iterations) > MAX_KDF_TOTAL_WORK {
         return Err("The vault KDF settings are outside Sesame's safe limits.".into());
     }
     let salt = URL_SAFE_NO_PAD

--- a/src-tauri/sesame-core/src/lib.rs
+++ b/src-tauri/sesame-core/src/lib.rs
@@ -77,9 +77,11 @@ pub const PAYLOAD_AAD: &[u8] = b"sesame:vault-payload:format:10:setup:complete";
 pub const HELLO_KEY_NAME_PREFIX: &str = "sesame-vault-hello-";
 pub const MAX_BACKUP_BYTES: u64 = 64 * 1024 * 1024;
 pub const MAX_VAULT_FILE_BYTES: u64 = 64 * 1024 * 1024;
-pub const MAX_KDF_MEMORY_KIB: u32 = 1_048_576;
-pub const MAX_KDF_ITERATIONS: u32 = 20;
+pub const MAX_KDF_MEMORY_KIB: u32 = 262_144;
+pub const MAX_KDF_ITERATIONS: u32 = 10;
 pub const MAX_KDF_PARALLELISM: u32 = 16;
+/// KiB multiplied by iterations; bounds the worst-case Argon2 cost an untrusted file can request.
+pub const MAX_KDF_TOTAL_WORK: u64 = 1_048_576;
 pub const SERVICE_CONNECTION_FORMAT_VERSION: u8 = 1;
 
 pub type VaultResult<T> = Result<T, String>;

--- a/src-tauri/sesame-core/src/platform/fs.rs
+++ b/src-tauri/sesame-core/src/platform/fs.rs
@@ -77,11 +77,7 @@ pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
     let parent = destination
         .parent()
         .ok_or("Sesame could not find the destination folder.")?;
-    let name = destination
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or("Sesame could not read the destination file name.")?;
-    let temporary = parent.join(format!(".{name}.{}.tmp", random_id()));
+    let temporary = parent.join(format!(".{}.tmp", random_id()));
     let write: VaultResult<()> = (|| {
         let mut output = open_private_file(&temporary)?;
         let mut input = std::fs::File::open(source)
@@ -186,20 +182,61 @@ pub fn securely_delete(path: &Path) -> VaultResult<()> {
         fs::remove_dir(path)
             .map_err(|_| "Sesame could not remove a staged vault directory.".to_string())?;
     } else if file_type.is_file() {
-        overwrite_file(path)?;
-        fs::remove_file(path)
-            .map_err(|_| "Sesame could not remove a staged vault file.".to_string())?;
+        overwrite_and_remove(path)?;
     }
     Ok(())
 }
 
-fn overwrite_file(path: &Path) -> VaultResult<()> {
-    use rand::Rng;
-    use std::io::Write;
-
-    let metadata = fs::metadata(path)
+/// Opens the file once, validates what the path points at, then removes the
+/// entry before overwriting the held descriptor. A link swapped into the path
+/// after the caller's check is removed, never written through.
+fn overwrite_and_remove(path: &Path) -> VaultResult<()> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true);
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        };
+        options.share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|_| "Sesame could not open a staged vault file for deletion.".to_string())?;
+    let opened = file
+        .metadata()
         .map_err(|_| "Sesame could not inspect a staged vault file.".to_string())?;
-    let len = metadata.len() as usize;
+    let entry = fs::symlink_metadata(path)
+        .map_err(|_| "Sesame could not inspect a staged vault entry.".to_string())?;
+    fs::remove_file(path)
+        .map_err(|_| "Sesame could not remove a staged vault file.".to_string())?;
+    if !entry_matches_open_file(&entry, &opened) {
+        return Ok(());
+    }
+    overwrite_open_file(&mut file, opened.len())
+}
+
+fn entry_matches_open_file(entry: &fs::Metadata, opened: &fs::Metadata) -> bool {
+    if !entry.file_type().is_file() || !opened.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        entry.dev() == opened.dev() && entry.ino() == opened.ino()
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn overwrite_open_file(file: &mut fs::File, len: u64) -> VaultResult<()> {
+    use rand::Rng;
+    use std::io::{Seek, SeekFrom, Write};
+
+    let len = len as usize;
     if len == 0 {
         return Ok(());
     }
@@ -217,10 +254,8 @@ fn overwrite_file(path: &Path) -> VaultResult<()> {
             chunk.fill(0x00);
         }
 
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .open(path)
-            .map_err(|_| "Sesame could not open a staged vault file for deletion.".to_string())?;
+        file.seek(SeekFrom::Start(0))
+            .map_err(|_| "Sesame could not rewind a staged vault file.".to_string())?;
         let mut remaining = len;
         while remaining > 0 {
             let to_write = chunk.len().min(remaining);

--- a/src-tauri/sesame-core/src/platform/fs.rs
+++ b/src-tauri/sesame-core/src/platform/fs.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use crate::util::random_id;
 use crate::VaultResult;
 
 #[cfg(windows)]
@@ -54,9 +55,8 @@ pub fn create_private_dir(path: &Path) -> VaultResult<()> {
 pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
     use std::os::unix::fs::OpenOptionsExt;
     std::fs::OpenOptions::new()
-        .create(true)
+        .create_new(true)
         .write(true)
-        .truncate(true)
         .mode(0o600)
         .open(path)
         .map_err(|_| "Sesame could not prepare the file.".to_string())
@@ -65,35 +65,41 @@ pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
 #[cfg(not(unix))]
 pub fn open_private_file(path: &Path) -> VaultResult<std::fs::File> {
     std::fs::OpenOptions::new()
-        .create(true)
+        .create_new(true)
         .write(true)
-        .truncate(true)
         .open(path)
         .map_err(|_| "Sesame could not prepare the file.".to_string())
 }
 
-#[cfg(unix)]
+/// A temp file in the destination folder plus a rename, so a planted link is
+/// replaced rather than followed.
 pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
-    use std::os::unix::fs::OpenOptionsExt;
-    let mut output = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(destination)
-        .map_err(|_| "Sesame could not write the vault copy.".to_string())?;
-    let mut input = std::fs::File::open(source)
-        .map_err(|_| "Sesame could not read the vault copy.".to_string())?;
-    std::io::copy(&mut input, &mut output)
-        .and_then(|_| output.sync_all())
-        .map_err(|_| "Sesame could not write the vault copy.".to_string())
-}
-
-#[cfg(not(unix))]
-pub fn copy_private_file(source: &Path, destination: &Path) -> VaultResult<()> {
-    fs::copy(source, destination)
-        .map(|_| ())
-        .map_err(|_| "Sesame could not write the vault copy.".to_string())
+    let parent = destination
+        .parent()
+        .ok_or("Sesame could not find the destination folder.")?;
+    let name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or("Sesame could not read the destination file name.")?;
+    let temporary = parent.join(format!(".{name}.{}.tmp", random_id()));
+    let write: VaultResult<()> = (|| {
+        let mut output = open_private_file(&temporary)?;
+        let mut input = std::fs::File::open(source)
+            .map_err(|_| "Sesame could not read the vault copy.".to_string())?;
+        std::io::copy(&mut input, &mut output)
+            .and_then(|_| output.sync_all())
+            .map_err(|_| "Sesame could not write the vault copy.".to_string())?;
+        Ok(())
+    })();
+    if let Err(error) = write {
+        let _ = fs::remove_file(&temporary);
+        return Err(error);
+    }
+    if let Err(error) = replace_file(&temporary, destination) {
+        let _ = fs::remove_file(&temporary);
+        return Err(error);
+    }
+    Ok(())
 }
 
 #[cfg(windows)]
@@ -160,7 +166,16 @@ pub fn same_file_identity(_source: &Path, _destination: &Path) -> bool {
 
 /// Best-effort secure deletion: overwrites with random bytes; wear-leveled storage cannot be guaranteed.
 pub fn securely_delete(path: &Path) -> VaultResult<()> {
-    if path.is_dir() {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(_) => return Err("Sesame could not inspect a staged vault entry.".to_string()),
+    };
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        fs::remove_file(path)
+            .map_err(|_| "Sesame could not remove a staged vault link.".to_string())?;
+    } else if file_type.is_dir() {
         for entry in fs::read_dir(path)
             .map_err(|_| "Sesame could not read a staged vault directory.".to_string())?
         {
@@ -170,7 +185,7 @@ pub fn securely_delete(path: &Path) -> VaultResult<()> {
         }
         fs::remove_dir(path)
             .map_err(|_| "Sesame could not remove a staged vault directory.".to_string())?;
-    } else if path.is_file() {
+    } else if file_type.is_file() {
         overwrite_file(path)?;
         fs::remove_file(path)
             .map_err(|_| "Sesame could not remove a staged vault file.".to_string())?;

--- a/src-tauri/sesame-core/src/storage.rs
+++ b/src-tauri/sesame-core/src/storage.rs
@@ -93,7 +93,11 @@ fn write_vault_file_inner(path: &Path, file: &VaultFile, retain_previous: bool) 
         .parent()
         .ok_or("Sesame could not find the local vault folder.")?;
     create_private_dir(parent)?;
-    let tmp_path = path.with_extension("sesame.tmp");
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or("Sesame could not read the local vault file name.")?;
+    let tmp_path = parent.join(format!(".{name}.{}.tmp", random_id()));
     let mut tmp = open_private_file(&tmp_path)?;
     tmp.write_all(&bytes)
         .and_then(|_| tmp.sync_all())

--- a/src-tauri/sesame-core/tests/vault_file_attacks.rs
+++ b/src-tauri/sesame-core/tests/vault_file_attacks.rs
@@ -7,9 +7,9 @@ use sesame_core::api::{
 };
 use sesame_core::{
     default_kdf_params, derive_key, encrypt_bytes, random_id, serialize_payload,
-    verify_backup_file, CipherBlob, KdfParams, VaultEntry, VaultFile, VaultPayload,
-    MAX_BACKUP_BYTES, MAX_KDF_ITERATIONS, MAX_KDF_MEMORY_KIB, MAX_KDF_PARALLELISM, PAYLOAD_AAD,
-    PENDING_SETUP_PAYLOAD_AAD, WRAP_AAD,
+    validate_kdf_params, verify_backup_file, CipherBlob, KdfParams, VaultEntry, VaultFile,
+    VaultPayload, MAX_BACKUP_BYTES, MAX_KDF_ITERATIONS, MAX_KDF_MEMORY_KIB, MAX_KDF_PARALLELISM,
+    MAX_KDF_TOTAL_WORK, PAYLOAD_AAD, PENDING_SETUP_PAYLOAD_AAD, WRAP_AAD,
 };
 
 const PASSWORD_A: &str = "fictional master password one";
@@ -274,6 +274,10 @@ fn kdf_parameters_outside_the_limits_are_refused_before_any_work() {
     let mut wrong_algorithm = default_kdf_params();
     wrong_algorithm.algorithm = "argon2i".to_string();
     hostile_params.push(wrong_algorithm);
+    let mut work_over = default_kdf_params();
+    work_over.memory_kib = MAX_KDF_MEMORY_KIB;
+    work_over.iterations = MAX_KDF_ITERATIONS;
+    hostile_params.push(work_over);
 
     for params in &hostile_params {
         assert!(derive_key(PASSWORD_A, params).is_err());
@@ -283,6 +287,25 @@ fn kdf_parameters_outside_the_limits_are_refused_before_any_work() {
     let mut hostile_file = file.clone();
     hostile_file.kdf.memory_kib = MAX_KDF_MEMORY_KIB + 1;
     assert!(open_vault_with_password(&hostile_file, PASSWORD_A).is_err());
+}
+
+#[test]
+fn kdf_work_above_the_aggregate_cap_is_refused() {
+    assert!(validate_kdf_params(&default_kdf_params()).is_ok());
+
+    let mut at_cap = default_kdf_params();
+    at_cap.memory_kib = (MAX_KDF_TOTAL_WORK / u64::from(MAX_KDF_ITERATIONS)) as u32;
+    at_cap.iterations = MAX_KDF_ITERATIONS;
+    assert!(validate_kdf_params(&at_cap).is_ok());
+
+    let mut over_cap = at_cap.clone();
+    over_cap.memory_kib += 1;
+    assert!(validate_kdf_params(&over_cap).is_err());
+
+    let mut high_memory = default_kdf_params();
+    high_memory.memory_kib = MAX_KDF_MEMORY_KIB;
+    high_memory.iterations = 5;
+    assert!(validate_kdf_params(&high_memory).is_err());
 }
 
 #[test]

--- a/src-tauri/sesame-core/tests/vault_file_symlink_boundaries.rs
+++ b/src-tauri/sesame-core/tests/vault_file_symlink_boundaries.rs
@@ -1,0 +1,142 @@
+use std::fs;
+use std::path::PathBuf;
+
+use sesame_core::api::{create_vault, open_vault_with_password};
+use sesame_core::loader::VaultLoader;
+use sesame_core::platform::{open_private_file, securely_delete};
+use sesame_core::storage::{commit_payload_change, persist_session};
+use sesame_core::{random_id, UnlockedVault};
+
+const PASSWORD: &str = "fictional master password";
+
+fn test_directory(name: &str) -> PathBuf {
+    let directory = std::env::temp_dir().join(format!("sesame-symlink-{name}-{}", random_id()));
+    fs::create_dir_all(&directory).expect("test directory");
+    directory
+}
+
+fn unlocked_session(path: &PathBuf) -> UnlockedVault {
+    let (opened, _) = create_vault(PASSWORD, "Fictional vault").expect("created vault");
+    let mut session = UnlockedVault::from_opened(path.clone(), &opened).expect("session");
+    session.setup_complete = true;
+    session
+}
+
+#[cfg(unix)]
+#[test]
+fn saving_a_vault_does_not_follow_a_symlink_at_the_legacy_temp_path() {
+    use std::os::unix::fs::symlink;
+
+    let directory = test_directory("legacy-temp");
+    let vault_path = directory.join("vault.sesame");
+    let canary_path = directory.join("canary.txt");
+    fs::write(&canary_path, b"fictional canary before save").expect("canary");
+    symlink(&canary_path, vault_path.with_extension("sesame.tmp")).expect("planted symlink");
+
+    let mut session = unlocked_session(&vault_path);
+    persist_session(&mut session).expect("save");
+
+    assert_eq!(
+        fs::read(&canary_path).expect("canary after"),
+        b"fictional canary before save"
+    );
+    let metadata = fs::symlink_metadata(&vault_path).expect("vault metadata");
+    assert!(metadata.file_type().is_file());
+    let file = VaultLoader::read(&vault_path).expect("read saved vault");
+    assert!(open_vault_with_password(&file, PASSWORD).is_ok());
+    fs::remove_dir_all(&directory).expect("cleanup");
+}
+
+#[cfg(unix)]
+#[test]
+fn the_previous_copy_does_not_follow_a_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let directory = test_directory("previous-copy");
+    let vault_path = directory.join("vault.sesame");
+    let mut session = unlocked_session(&vault_path);
+    persist_session(&mut session).expect("first save");
+    let first = fs::read(&vault_path).expect("first bytes");
+
+    let canary_path = directory.join("canary-prev.txt");
+    fs::write(&canary_path, b"fictional previous canary").expect("canary");
+    symlink(&canary_path, vault_path.with_extension("sesame.prev")).expect("planted symlink");
+
+    let mut payload = session.open_payload().expect("payload").clone();
+    payload.vault_name = "Changed fictional vault".to_string();
+    commit_payload_change(&mut session, payload).expect("second save");
+
+    assert_eq!(
+        fs::read(&canary_path).expect("canary after"),
+        b"fictional previous canary"
+    );
+    assert_eq!(
+        fs::read(vault_path.with_extension("sesame.prev")).expect("previous copy"),
+        first
+    );
+    fs::remove_dir_all(&directory).expect("cleanup");
+}
+
+#[cfg(unix)]
+#[test]
+fn saving_over_a_planted_symlink_replaces_the_link_and_not_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let directory = test_directory("vault-link");
+    let vault_path = directory.join("vault.sesame");
+    let canary_path = directory.join("canary.txt");
+    fs::write(&canary_path, b"fictional canary at the vault path").expect("canary");
+    symlink(&canary_path, &vault_path).expect("planted symlink");
+
+    let mut session = unlocked_session(&vault_path);
+    persist_session(&mut session).expect("save");
+
+    assert_eq!(
+        fs::read(&canary_path).expect("canary after"),
+        b"fictional canary at the vault path"
+    );
+    let metadata = fs::symlink_metadata(&vault_path).expect("vault metadata");
+    assert!(metadata.file_type().is_file());
+    fs::remove_dir_all(&directory).expect("cleanup");
+}
+
+#[cfg(unix)]
+#[test]
+fn private_file_creation_refuses_an_existing_path() {
+    use std::os::unix::fs::symlink;
+
+    let directory = test_directory("open-private");
+    let canary_path = directory.join("canary.txt");
+    fs::write(&canary_path, b"fictional canary protected").expect("canary");
+    let link_path = directory.join("linked.bin");
+    symlink(&canary_path, &link_path).expect("planted symlink");
+
+    assert!(open_private_file(&link_path).is_err());
+    assert!(open_private_file(&canary_path).is_err());
+    assert_eq!(
+        fs::read(&canary_path).expect("canary after"),
+        b"fictional canary protected"
+    );
+    fs::remove_dir_all(&directory).expect("cleanup");
+}
+
+#[cfg(unix)]
+#[test]
+fn secure_deletion_removes_a_link_without_overwriting_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let directory = test_directory("secure-delete");
+    let canary_path = directory.join("canary.txt");
+    fs::write(&canary_path, b"fictional canary for deletion").expect("canary");
+    let link_path = directory.join("staged.bin");
+    symlink(&canary_path, &link_path).expect("planted symlink");
+
+    securely_delete(&link_path).expect("deleted link");
+
+    assert!(!link_path.exists());
+    assert_eq!(
+        fs::read(&canary_path).expect("canary after"),
+        b"fictional canary for deletion"
+    );
+    fs::remove_dir_all(&directory).expect("cleanup");
+}


### PR DESCRIPTION
## Scope

- Area: vault core
- Linked issue: none
- Depends on: nothing

## What changed

Vault saves used a deterministic `.sesame.tmp` beside the vault, and both the temporary write and the previous-copy write followed an existing symlink with truncate. A planted link could overwrite any file the user can write and replace the vault path with a link. Saves now use a random temp name created with `create_new`, which refuses to open an existing path or link, and the previous copy is written to a temp file and renamed over the destination. Secure deletion removes a link instead of overwriting its target.

A vault file also chose its own Argon2id parameters, and the accepted maximum of 1 GiB and 20 iterations took about 248 seconds and 1,028 MiB in a probe. Memory now caps at 256 MiB, iterations at 10, and total work at 1,048,576 KiB-iterations. Default vaults at 64 MiB and 3 iterations, and every compatibility fixture, stay inside the caps.

## Security and data boundary

- [x] This does not send vault contents, passwords, TOTP seeds, recovery data, or encryption keys to a Sesame service.
- [x] I reviewed changes to unlock, encryption, backup, import, browser messaging, authentication, or audit behaviour.
- [x] Any new logs and diagnostics are secret-safe.

The symlink fix closes a local file-integrity path where a link planted in the vault directory could redirect a save. The KDF change bounds the work an untrusted vault can request before any derivation runs. No key material, vault contents, or diagnostics changed. A file beyond the caps fails closed with the existing unsafe-KDF error.

## Validation

```text
cargo fmt --manifest-path src-tauri/Cargo.toml --all --check     passed
cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets  passed
cargo test --manifest-path src-tauri/Cargo.toml                  passed (24 suites, 327 tests)
```

The five symlink regression tests fail against the pre-fix baseline and pass with the change. The KDF boundary test accepts a vault exactly at the work cap and rejects the next step.

## Evidence

Local runs on this branch. The pull request runs the required checks.

## Review notes

- [x] Generated output and local state are not included.
- [x] Documentation matches the implemented state.
- [x] This change is safe to revert independently, or the dependency is documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added stricter limits on password-derived key generation to reduce excessive resource usage.
  * Vault file operations now prevent accidental overwrites and handle temporary files more safely.
  * Improved protection against symbolic links during vault creation, copying, and deletion.
  * Existing files are no longer truncated when secure file creation is attempted.
  * Missing files are handled gracefully during secure deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->