### PR TITLE
Keep native replies inside the host frame budget

### DIFF
--- a/src-tauri/src/adapters/platform/browser_host/mod.rs
+++ b/src-tauri/src/adapters/platform/browser_host/mod.rs
@@ -2,6 +2,7 @@ use std::io::{self, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
+use zeroize::Zeroizing;
 
 use crate::browser_protocol::{
     supported_protocol_version, BrowserRequest, BrowserResponse, MAX_NATIVE_MESSAGE_BYTES,
@@ -444,7 +445,7 @@ where
                 "invalid native message size",
             ));
         }
-        let mut payload = vec![0_u8; size];
+        let mut payload = Zeroizing::new(vec![0_u8; size]);
         input.read_exact(&mut payload)?;
         let request = match serde_json::from_slice::<BrowserRequest>(&payload) {
             Ok(request) => request,
@@ -486,7 +487,7 @@ where
 }
 
 fn desktop_response(request: &BrowserRequest) -> BrowserResponse {
-    let request_bytes = match serde_json::to_vec(request) {
+    let request_bytes = match request.to_zeroizing_bytes() {
         Ok(bytes) if !bytes.is_empty() && bytes.len() <= MAX_NATIVE_MESSAGE_BYTES => bytes,
         _ => return unavailable_without_desktop(request),
     };
@@ -501,16 +502,15 @@ fn desktop_response(request: &BrowserRequest) -> BrowserResponse {
 }
 
 fn unavailable_without_desktop(request: &BrowserRequest) -> BrowserResponse {
-    if request.message_type == "capabilities" {
-        BrowserResponse::capabilities(&request.request_id, false, true)
-    } else if request.message_type == "activate" {
-        BrowserResponse::activated(&request.request_id, launch_desktop_app())
-    } else {
-        if request.message_type == "card" {
-            BrowserResponse::card_unavailable(&request.request_id, "desktopUnavailable")
-        } else {
-            BrowserResponse::unavailable(&request.request_id, "desktopUnavailable")
+    match request.message_type.as_str() {
+        "capabilities" => BrowserResponse::capabilities(&request.request_id, false, true),
+        "activate" => BrowserResponse::activated(&request.request_id, launch_desktop_app()),
+        "identity" => {
+            BrowserResponse::identity_unavailable(&request.request_id, "desktopUnavailable")
         }
+        "save" => BrowserResponse::save_unavailable(&request.request_id, "desktopUnavailable"),
+        "card" => BrowserResponse::card_unavailable(&request.request_id, "desktopUnavailable"),
+        _ => BrowserResponse::unavailable(&request.request_id, "desktopUnavailable"),
     }
 }
 
@@ -675,5 +675,75 @@ mod lifecycle_tests {
             Some(std::ffi::OsStr::new("unregister")),
             None
         ));
+    }
+}
+
+#[cfg(test)]
+mod boundary_tests {
+    use super::*;
+
+    fn request(message_type: &str) -> BrowserRequest {
+        let card = message_type == "card";
+        BrowserRequest {
+            version: if card { 2 } else { 1 },
+            message_type: message_type.to_string(),
+            request_id: "request-1".to_string(),
+            origin: Some("https://example.test".to_string()),
+            fields: if message_type == "identity" {
+                Some("email".to_string())
+            } else if card {
+                Some("number".to_string())
+            } else {
+                None
+            },
+            username: None,
+            password: (message_type == "save").then(|| "fictional-password".to_string()),
+            title: None,
+            kind: (message_type == "save").then(|| "new".to_string()),
+        }
+    }
+
+    #[test]
+    fn unavailable_fallbacks_carry_the_request_type() {
+        for (message_type, expected) in [
+            ("identity", "identity-unavailable"),
+            ("save", "save-unavailable"),
+            ("fill", "fill-unavailable"),
+            ("card", "card-unavailable"),
+        ] {
+            let request = request(message_type);
+            assert!(request.validate(), "{message_type} request validates");
+            let response = unavailable_without_desktop(&request);
+            assert_eq!(response.message_type, expected);
+            assert!(
+                response.validate_for(&request),
+                "{expected} binds to its request"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_frames_end_the_host_without_a_response() {
+        let mut zero_size: &[u8] = &[0, 0, 0, 0];
+        let mut output = Vec::new();
+        let error = serve_with_relay(&mut zero_size, &mut output, |_| unreachable!())
+            .expect_err("a zero size frame fails");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+
+        let oversize = (MAX_NATIVE_MESSAGE_BYTES as u32 + 1).to_le_bytes();
+        let mut oversize_reader: &[u8] = &oversize;
+        let mut output = Vec::new();
+        let error = serve_with_relay(&mut oversize_reader, &mut output, |_| unreachable!())
+            .expect_err("an oversize frame fails");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+
+        let payload = b"{";
+        let mut invalid: Vec<u8> = (payload.len() as u32).to_le_bytes().to_vec();
+        invalid.extend_from_slice(payload);
+        let mut invalid_reader: &[u8] = &invalid;
+        let mut output = Vec::new();
+        let error = serve_with_relay(&mut invalid_reader, &mut output, |_| unreachable!())
+            .expect_err("invalid JSON fails");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
     }
 }

--- a/src-tauri/src/browser_protocol.rs
+++ b/src-tauri/src/browser_protocol.rs
@@ -165,6 +165,10 @@ impl BrowserRequest {
             _ => false,
         }
     }
+
+    pub fn to_zeroizing_bytes(&self) -> Result<Zeroizing<Vec<u8>>, serde_json::Error> {
+        serde_json::to_vec(self).map(Zeroizing::new)
+    }
 }
 
 /// Only the subset the page asked for and the approval granted.
@@ -536,7 +540,7 @@ impl BrowserResponse {
         if request.message_type != "card" && !no_card {
             return false;
         }
-        match (request.message_type.as_str(), self.message_type.as_str()) {
+        let allowed = match (request.message_type.as_str(), self.message_type.as_str()) {
             ("capabilities", "capabilities") => {
                 self.installed == Some(true)
                     && self.desktop_available.is_some()
@@ -672,7 +676,15 @@ impl BrowserResponse {
                     && self.message.as_deref().is_some_and(valid_error_message)
             }
             _ => false,
-        }
+        };
+        allowed && self.within_message_budget()
+    }
+
+    /// Every accepted response must fit the frame the host can write.
+    fn within_message_budget(&self) -> bool {
+        self.to_zeroizing_bytes()
+            .map(|bytes| !bytes.is_empty() && bytes.len() <= MAX_NATIVE_MESSAGE_BYTES)
+            .unwrap_or(false)
     }
 
     pub fn to_zeroizing_bytes(&self) -> Result<Zeroizing<Vec<u8>>, serde_json::Error> {
@@ -851,5 +863,60 @@ mod tests {
                 let _ = request.validate();
             }
         }
+    }
+
+    #[test]
+    fn an_identity_response_over_the_message_budget_is_refused() {
+        let mut identity_request = request(PROTOCOL_VERSION, "identity");
+        identity_request.fields = Some(IDENTITY_FIELD_KEYS.join(","));
+        assert!(identity_request.validate());
+
+        let big = "x".repeat(MAX_CREDENTIAL_FIELD_BYTES);
+        let oversize = BrowserResponse::identity_for(
+            &identity_request,
+            IdentityFillFields {
+                full_name: Some(big.clone()),
+                email: Some(big.clone()),
+                phone: Some(big.clone()),
+                address_line1: Some(big.clone()),
+                address_line2: Some(big.clone()),
+                city: Some(big.clone()),
+                region: Some(big.clone()),
+                postal_code: Some(big.clone()),
+                country: Some(big),
+            },
+        );
+        assert!(!oversize.validate_for(&identity_request));
+
+        let mut small_request = request(PROTOCOL_VERSION, "identity");
+        small_request.fields = Some("fullName,email".to_string());
+        assert!(small_request.validate());
+        let typical = BrowserResponse::identity_for(
+            &small_request,
+            IdentityFillFields {
+                full_name: Some("Fictional Person".to_string()),
+                email: Some("fictional@example.test".to_string()),
+                ..IdentityFillFields::default()
+            },
+        );
+        assert!(typical.validate_for(&small_request));
+    }
+
+    #[test]
+    fn the_largest_save_request_fits_the_frame_budget() {
+        let save = BrowserRequest {
+            version: PROTOCOL_VERSION,
+            message_type: "save".to_string(),
+            request_id: "request-1".to_string(),
+            origin: Some(format!("https://{}.example.test", "a".repeat(2000))),
+            fields: None,
+            username: Some("u".repeat(MAX_CREDENTIAL_FIELD_BYTES)),
+            password: Some("p".repeat(MAX_CREDENTIAL_FIELD_BYTES)),
+            title: Some("t".repeat(512)),
+            kind: Some("new".to_string()),
+        };
+        assert!(save.validate());
+        let bytes = save.to_zeroizing_bytes().expect("the request encodes");
+        assert!(bytes.len() <= MAX_NATIVE_MESSAGE_BYTES);
     }
 }


### PR DESCRIPTION
## Scope

- Area: native host
- Linked issue: SEC-2026-005 and SEC-2026-006 in the private handoff
- Depends on: the merge of #57

## What changed

A response that passes request binding can no longer be larger than the frame the host can write. Response validation now also requires the encoded response to fit `MAX_NATIVE_MESSAGE_BYTES`, so the host answers with a small typed unavailable response instead of exiting. Before this, an identity response with several large fields passed validation at 37,055 bytes against the 16,384-byte cap, and the host terminated mid-autofill.

Identity and save requests now get `identity-unavailable` and `save-unavailable` when the desktop is unreachable. The old fallback sent `fill-unavailable` for both, which failed validation against the request and killed the host. The fallback types now pass `validate_for`.

The host reads a frame into a zeroizing buffer, and `BrowserRequest` gained the same `to_zeroizing_bytes` serializer the response already used, so the relay no longer keeps a plain copy of a save request's username and password.

## Security and data boundary

- [x] This does not send vault contents, passwords, TOTP seeds, recovery data, or encryption keys to a Sesame service.
- [x] I reviewed changes to unlock, encryption, backup, import, browser messaging, authentication, or audit behaviour.
- [x] Any new logs and diagnostics are secret-safe.
- [ ] Not applicable; this change does not touch a security or data boundary.

The browser host relays closed-schema requests and responses. This change keeps every accepted response within the frame budget and makes the credential-lifetime handling match the response path. No credential value is logged or persisted.

## Validation

```text
cargo fmt --manifest-path src-tauri/Cargo.toml --all --check
cargo test --manifest-path src-tauri/Cargo.toml -p sesame --lib browser_protocol
cargo test --manifest-path src-tauri/Cargo.toml -p sesame --lib boundary_tests
npm run desktop:lint:rust
npm run desktop:test:rust
```

All passed. The new tests: `an_identity_response_over_the_message_budget_is_refused`, `the_largest_save_request_fits_the_frame_budget`, `unavailable_fallbacks_carry_the_request_type`, and `malformed_frames_end_the_host_without_a_response`.

## Evidence

The probe that reproduced SEC-2026-005 is in the private handoff at `native-boundary-pentest-20260912/`. It encoded a valid nine-field identity response at 37,055 bytes against the 16,384-byte cap. The first new test pins that boundary; the second pins the largest valid save request inside the frame.

## Review notes

- [x] Generated output and local state are not included.
- [x] Documentation matches the implemented state.
- [x] This change is safe to revert independently, or the dependency is documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive browser communication data is now cleared from memory after use.
  * Native messages are checked against size limits before being accepted.

* **Bug Fixes**
  * Unavailable identity and save actions now return specific fallback responses.
  * Malformed browser messages are handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->